### PR TITLE
added support for horizontal skipping in vector cross section displays

### DIFF
--- a/src/ucar/unidata/idv/control/CrossSectionControl.java
+++ b/src/ucar/unidata/idv/control/CrossSectionControl.java
@@ -267,6 +267,8 @@ public abstract class CrossSectionControl extends GridDisplayControl implements 
     /** old smoothing factor */
     private int OldSmoothingFactor = 0;
 
+    /** horizontal skip value */
+    int skipValue = 0;
     /**
      * Default constructor.  Sets the appropriate attribute flags.
      */
@@ -1638,6 +1640,10 @@ public abstract class CrossSectionControl extends GridDisplayControl implements 
                 && !getSmoothingType().equals(LABEL_NONE)) {
             slice = GridUtil.smooth(slice, getSmoothingType(),
                                     getSmoothingFactor());
+        }
+        // apply skip factor
+        if (getSkipValue() > 0) {
+            slice = GridUtil.subset(slice, getSkipValue() + 1, 1);
         }
         loadData(slice);
     }

--- a/src/ucar/unidata/idv/control/FlowCrossSectionControl.java
+++ b/src/ucar/unidata/idv/control/FlowCrossSectionControl.java
@@ -34,6 +34,7 @@ import ucar.unidata.util.Misc;
 import ucar.unidata.util.Range;
 import ucar.unidata.util.Trace;
 
+import ucar.visad.display.CrossSectionSelector;
 import ucar.visad.display.DisplayableData;
 import ucar.visad.display.FlowDisplayable;
 import ucar.visad.display.WindBarbDisplayable;
@@ -81,6 +82,9 @@ public class FlowCrossSectionControl extends CrossSectionControl implements Flow
     /** Widget to set barb size */
     ValueSliderWidget barbSizeWidget;
 
+    /** a component to change the skip */
+    ValueSliderWidget skipFactorWidget;
+
     /**
      * Create a new FlowCrossSectionControl; set attribute flags
      */
@@ -96,7 +100,7 @@ public class FlowCrossSectionControl extends CrossSectionControl implements Flow
         super.initDone();
         setFlowScale(flowScaleValue);
         ((FlowDisplayable) getXSDisplay()).setAdjustFlow(
-            getIsThreeComponents());
+                getIsThreeComponents());
     }
 
     /**
@@ -138,10 +142,9 @@ public class FlowCrossSectionControl extends CrossSectionControl implements Flow
                              "Scale", SETTINGS_GROUP_DISPLAY);
         dsd.addPropertyValue(flowRange, "flowRange", "Flow Field Range",
                              SETTINGS_GROUP_DISPLAY);
+        dsd.addPropertyValue(new Integer(getSkipValue()), "skipValue",
+                             "Skip Factor", SETTINGS_GROUP_DISPLAY);
     }
-
-
-
 
     /**
      * Called to initialize this control from the given dataChoice;
@@ -245,6 +248,11 @@ public class FlowCrossSectionControl extends CrossSectionControl implements Flow
         barbSizeWidget = new ValueSliderWidget(this, 1, 21, "flowScale",
                 "Scale: ");
         addRemovable(barbSizeWidget);
+
+        skipFactorWidget = new ValueSliderWidget(this, 0, 10, "skipValue",
+                getSkipWidgetLabel());
+        addRemovable(skipFactorWidget);
+
         JPanel extra = GuiUtils.hbox(GuiUtils.rLabel("Scale:  "),
                                      barbSizeWidget.getContents(false));
         if ( !getWindbarbs()) {
@@ -255,6 +263,14 @@ public class FlowCrossSectionControl extends CrossSectionControl implements Flow
         controlWidgets.add(new WrapperWidget(this,
                                              GuiUtils.rLabel(getSizeLabel()),
                                              GuiUtils.left(extra)));
+        controlWidgets.add(
+            new WrapperWidget(
+                this, GuiUtils.rLabel("Skip:"),
+                GuiUtils.left(
+                    GuiUtils.hbox(
+                        GuiUtils.rLabel("Horizontal:  "),
+                        skipFactorWidget.getContents(false)))));
+
         super.getControlWidgets(controlWidgets);
 
     }
@@ -346,6 +362,23 @@ public class FlowCrossSectionControl extends CrossSectionControl implements Flow
      */
     public boolean getWindbarbs() {
         return isWindBarbs;
+    }
+
+
+    /**
+     * Set the  skip value
+     *
+     * @param value skip value
+     **/
+
+    public void setSkipValue(int value) {
+        super.setSkipValue(value);
+        if (skipFactorWidget != null) {
+            skipFactorWidget.setValue(value);
+        }
+        if (getCrossSectionSelector() != null) {
+            crossSectionChanged();
+        }
     }
 
 


### PR DESCRIPTION
The changes in this request enable users to specify a skip factor (horizontal) for vector cross section displays. I'd like to allow users to specify a skip factor for the vertical coordinate as well, but it seems like it'd take a bit of work to add that ability (perhaps a complete refactor of the skipping code to allow skipping along each spatial dimension?). Please review - I just played parrot with what I saw in PlanViewControl.java and FlowPlanViewControl.java, so I may have missed something.

Sean
