### PR TITLE
removed idvjar target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -230,15 +230,7 @@ argument -Dfoo=bar) -->
         </exec>
     </target>
 
-
-
-    <target name="idvjar" depends="init">
-        <antcall target="clean"/>
-        <antcall target="jaridv"/>
-    </target>
-
-
-    <target name="jaridv" depends="init">
+    <target name="jaridv" depends="init" description="Builds a new idv.jar.">
         <antcall target="idv"/>
         <!--  Moved to idv target
         <copy overwrite="true" file="${sourcedir}/ucar/unidata/idv/resources/version.properties" tofile="${sourcedir}/ucar/unidata/idv/resources/build.properties">


### PR DESCRIPTION
In the spirit of fixing little annoyances in build.xml, I removed jaridv (which I always get confused with idvjar). If someone really loves the functionality, they could always just run `ant clean jaridv`.
