### PR TITLE
Fix to set missing ints to NaN when reading netCDF grid files

### DIFF
--- a/src/ucar/unidata/data/grid/GeoGridAdapter.java
+++ b/src/ucar/unidata/data/grid/GeoGridAdapter.java
@@ -1283,6 +1283,7 @@ public class GeoGridAdapter {
             final float[][] fieldArray = new float[1][];
             //fieldArray[0] = DataUtil.toFloatArray(arr);
             float[] values = DataUtil.toFloatArray(arr);
+            values = geoGrid.setMissingToNaN(values);
             if (values.length < domainSet.getLength()) {  // need to extend array
                 float[] newValues = new float[domainSet.getLength()];
                 int[]   lengths   = domainSet.getLengths();

--- a/src/ucar/visad/data/GeoGridFlatField.java
+++ b/src/ucar/visad/data/GeoGridFlatField.java
@@ -290,6 +290,7 @@ public class GeoGridFlatField extends CachedFlatField {
         float[][] fieldArray = new float[1][];
         //fieldArray[0] = DataUtil.toFloatArray(arr);
         float[] values = DataUtil.toFloatArray(arr);
+        values = geoGrid.setMissingToNaN(values);
         Trace.call2("toFloatArray", " length:" + values.length);
         // if we have extended the longitudes, we need to add more points.
         try {


### PR DESCRIPTION
The IDV was not recognizing "missing values" for variables that were not of type float or double.  With considerable help from Don (thank you!), the code was changed so that when reading a variable the netCDF library's GeoGrid.setMIssingToNaN() is now called to insure that missing values are set to NaN before stuffing these into a VisAD FlatField.  
