### PR TITLE
createEquivalentPotentialTemperature fails for FlatField's

### DIFF
--- a/src/ucar/unidata/data/grid/DerivedGridFactory.java
+++ b/src/ucar/unidata/data/grid/DerivedGridFactory.java
@@ -2155,18 +2155,18 @@ public class DerivedGridFactory {
         TupleType    rangeType = null;
         FunctionType innerType = null;
         FlatField    press     = null;
-        if (ensble) {
-            FieldImpl sample1 = (FieldImpl) temperFI.getSample(0);
-            press =
-                createPressureGridFromDomain((FlatField) sample1.getSample(0,
-                    false));
-        } else {
-            press = createPressureGridFromDomain(
-                (FlatField) temperFI.getSample(0));
-        }
 
 
         if (isSequence) {
+            if (ensble) {
+                FieldImpl sample1 = (FieldImpl) temperFI.getSample(0);
+                press =
+                    createPressureGridFromDomain((FlatField) sample1.getSample(0,
+                        false));
+            } else {
+                press = createPressureGridFromDomain(
+                    (FlatField) temperFI.getSample(0));
+            }
 
             // Implementation:  have to take the raw time series of data FieldImpls
             // apart, make the ept FlatField by FlatField (for each time step),


### PR DESCRIPTION
Hello,
Currently, createEquivalentPotentialTemperature fails in the case where both input arguments are FlatField's.

I fixed this by simply moving the "temperFI.getSample(0)" calls in to the "if (isSequence)" block (following what is done in createMixingRatio, which works fine).

I've tested on both time-sequence FieldImpl's and simple FlatField's, but have not tested the case of ensemble grids.

Thanks, let me know if I can provide more info!
Mike
