### PR TITLE
Remove 'All levels' option from Point Data level selection widget 

### DIFF
--- a/src/ucar/unidata/data/DataSource.java
+++ b/src/ucar/unidata/data/DataSource.java
@@ -488,9 +488,12 @@ public interface DataSource {
      */
     public void setObjectProperties(Hashtable properties);
 
-
-
-
+    /**
+     * Whether this DataSource to do "All levels"
+     *
+     * @return boolean
+     */
+     public boolean canDoAllLevels();
 
     /**
      *  Set the DataIsEditable property.

--- a/src/ucar/unidata/data/DataSourceImpl.java
+++ b/src/ucar/unidata/data/DataSourceImpl.java
@@ -391,7 +391,15 @@ public class DataSourceImpl extends SharableImpl implements DataSource,
     }
 
 
+    /** 
+     * Can this handle "All levels"?
+     *
+     * @return true
+     */
 
+     public boolean canDoAllLevels() {
+       return true;
+     }
 
     /**
      * Get the IDV

--- a/src/ucar/unidata/data/point/PointDataSource.java
+++ b/src/ucar/unidata/data/point/PointDataSource.java
@@ -1627,4 +1627,14 @@ public abstract class PointDataSource extends FilesDataSource {
         return makeGridFields;
     }
 
+    /**
+     * Cannot do all levels!
+     *
+     * @return false
+     *
+     */
+     public boolean canDoAllLevels() {
+       return false;
+     }
+
 }

--- a/src/ucar/unidata/idv/ui/DataSelectionWidget.java
+++ b/src/ucar/unidata/idv/ui/DataSelectionWidget.java
@@ -326,7 +326,8 @@ public class DataSelectionWidget {
                     && (levelsFromDisplay == null))) {
             return NO_LEVELS;
         }
-        int indexOffset = ((levelsFromDisplay == null)
+        int indexOffset = ((levelsFromDisplay == null && 
+           (lastDataSource != null && lastDataSource.canDoAllLevels()) )
                            ? 1
                            : 0);
         if (selected.length == 1) {
@@ -585,7 +586,7 @@ public class DataSelectionWidget {
                 levelsTab = levelsScroller;
             }
             Vector levelsForGui = new Vector();
-            if (levelsFromDisplay == null) {
+            if (levelsFromDisplay == null && dataSource.canDoAllLevels() ) {
                 levelsForGui.add(new TwoFacedObject("All Levels", null));
             }
             for (int i = 0; i < levels.size(); i++) {


### PR DESCRIPTION
to make the level choice consistent across all menus.  Added "canDoAllLevels()" method so that each DataSourceImpl can make it known to the world.  This affects the data selection widget that appears in the Field Selector when "levels" are available.  The default is "true", but PointDataSource data were set to "false" since "All levels" is not appropriate for point data.
