### PR TITLE
Quiet javadoc warning introduced with my last pull req.

### DIFF
--- a/src/ucar/unidata/util/ContourInfo.java
+++ b/src/ucar/unidata/util/ContourInfo.java
@@ -823,7 +823,7 @@ public class ContourInfo {
     /**
      * Get the label frequency
      *
-     * @param size the label frequency
+     * @param freq the label frequency
      */
     public void setLabelFreq(int freq) {
         this.labelFreq = freq;


### PR DESCRIPTION
Cosmetic change only guys - noticed this when updating and building today.  Just cleans up some bad javadoc from my previous commit.
