### PR TITLE
Fix Bug #52 - default level for gridding point data issue

### DIFF
--- a/src/ucar/unidata/data/point/PointDataSource.java
+++ b/src/ucar/unidata/data/point/PointDataSource.java
@@ -1010,7 +1010,7 @@ public abstract class PointDataSource extends FilesDataSource {
                             }
                             DataChoice gridChoice =
                                 new DirectDataChoice(this, idList, name,
-                                    name, gridCategories, (Hashtable) null);
+                                    name, gridCategories, properties);
                             compositeDataChoice.addDataChoice(gridChoice);
                         }
                     }


### PR DESCRIPTION
Pass along the properties in order to get the chosen level.  The issue was that the level chosen in the Point Chooser was not passed along when in the Field Selector you picked "Gridded data -> param".  It was passed along if you picked "RAOB Point Data", though.
