### PR TITLE
Remove 'Point Cloud' option for Text files [1370]

### DIFF
--- a/src/ucar/unidata/data/point/TextPointDataSource.java
+++ b/src/ucar/unidata/data/point/TextPointDataSource.java
@@ -2535,6 +2535,7 @@ public class TextPointDataSource extends PointDataSource {
             //Sample the data to see if we need to show the metadata gui
             Data sample = makeObs(dataChoice, null, null, null, true, true);
 
+            /*  Remove this option ... Control cannot subset/clip correctly
             List cloudCats =
                 DataCategory.parseCategories("Point Cloud;pointcloud", true);
             for (String varname : varNames) {
@@ -2543,6 +2544,7 @@ public class TextPointDataSource extends PointDataSource {
                                         varname, cloudCats, (Hashtable) null);
                 addDataChoice(choice);
             }
+            */
             if (isTrajectoryEnabled()) {
 
                 //                System.err.println ("sample:" + sample);


### PR DESCRIPTION
Based on Don and Jeff's advice, I have removed (by commenting out lines of code) the "Point Cloud"  option for Text type data, as the option is really designed for massive amounts of point data which is not really appropriate for Text type data sources.   [The issue came to light when a user tried to subset/clip some text-type point data (with one ob over many time steps) in the Point Cloud Control, and an invalid cast exception is thrown.]
