### PR TITLE
For ADDE Upper Air Point contour displays, make the level labels 'SFC'

### DIFF
--- a/src/ucar/unidata/idv/control/PlanViewControl.java
+++ b/src/ucar/unidata/idv/control/PlanViewControl.java
@@ -1410,6 +1410,9 @@ public abstract class PlanViewControl extends GridDisplayControl {
      * Format the level for labelling.  If subclasses want to have
      * different formatting, they can override this method.
      *
+     * Check for 'currentLevel' to have a non-numeric: SFC, MSL, or TRO
+     * and if so, return just that String...
+     *
      * @param level  level to format
      *
      * @return formatted string for level
@@ -1421,9 +1424,19 @@ public abstract class PlanViewControl extends GridDisplayControl {
 
         Real         myLevel = getLevelReal(level);
         StringBuffer buf     = new StringBuffer();
-        buf.append(getDisplayConventions().format(myLevel.getValue()));
-        buf.append(" ");
-        buf.append(myLevel.getUnit());
+        if ( (currentLevel != null) && currentLevel.toString().equals("SFC") ) {
+          buf.append("SFC ");
+        } else if ( (currentLevel != null) &&
+                 currentLevel.toString().equals("MSL") ) {
+          buf.append("MSL ");
+        } else if ( (currentLevel != null) &&
+                 currentLevel.toString().equals("TRO") ) {
+          buf.append("TRO ");
+        } else {
+          buf.append(getDisplayConventions().format(myLevel.getValue()));
+          buf.append(" ");
+          buf.append(myLevel.getUnit());
+        }
         return buf.toString();
     }
 


### PR DESCRIPTION
instead of "1001 hPa".  Modified PlanViewControl's formatLevel() method to look at the value of the 'currentLevel' variable, and if it's SFC, MSL or TRO, then I just return those Strings, which are then used for labeling in the Control and in the Legend...
