### PR TITLE
Better validation for numeric ranges

### DIFF
--- a/src/ucar/unidata/idv/control/ColorTableWidget.java
+++ b/src/ucar/unidata/idv/control/ColorTableWidget.java
@@ -508,9 +508,10 @@ public class ColorTableWidget extends ControlWidget implements PropertyChangeLis
                 if (cmd.equals(GuiUtils.CMD_OK)
                         || cmd.equals(GuiUtils.CMD_APPLY)) {
                     try {
-                        double dLo = Double.valueOf(rangeMinField.getText()).doubleValue();
-                        double dHi = Double.valueOf(rangeMaxField.getText()).doubleValue();
-                        Range newRange = new Range(dLo, dHi);
+                        Range newRange =
+                            new Range(
+                                Misc.parseNumber(rangeMinField.getText()),
+                                Misc.parseNumber(rangeMaxField.getText()));
                         handleNewRange(newRange);
                     } catch (NumberFormatException pe) {
                         LogUtil.userMessage("Invalid numeric format");

--- a/src/ucar/unidata/idv/control/RangeDialog.java
+++ b/src/ucar/unidata/idv/control/RangeDialog.java
@@ -152,9 +152,11 @@ public class RangeDialog implements RangeWidget, Removable {
                 if (cmd.equals(GuiUtils.CMD_OK)
                         || cmd.equals(GuiUtils.CMD_APPLY)) {
                     try {
-                        double dLo = Double.valueOf(rangeMinField.getText()).doubleValue();
-                        double dHi = Double.valueOf(rangeMaxField.getText()).doubleValue();
-                        Range newRange = new Range(dLo, dHi);
+                        Range newRange =
+                                new Range(
+                                    Misc.parseNumber(rangeMinField.getText()),
+                                    Misc.parseNumber(rangeMaxField.getText()));
+                            handleNewRange(newRange);
                         handleNewRange(newRange);
                     } catch (NumberFormatException pe) {
                         LogUtil.userMessage("Invalid numeric format");

--- a/src/ucar/unidata/util/Misc.java
+++ b/src/ucar/unidata/util/Misc.java
@@ -1953,7 +1953,6 @@ public class Misc {
 
     /** decimal format for scientific notation */
     static DecimalFormat format1 = new DecimalFormat("0.#E0");
-    //new DecimalFormat("#.00000");
 
     /** decimal format for 4 places after the decimal point */
     static DecimalFormat format2 = new DecimalFormat("#.00##");
@@ -1977,8 +1976,8 @@ public class Misc {
      * Return different pre-defined DecimalFormat objects depending
      * on the value of the given double
      *
-     * @param v  valut in question
-     * @return   appropriate formatter
+     * @param v  value in question
+     * @return   appropriate decimal format pattern
      */
     public static DecimalFormat getDecimalFormat(double v) {
         v = Math.abs(v);
@@ -2056,6 +2055,8 @@ public class Misc {
             return Double.NaN;
         }
         try {
+            // hack to also accept lower case e for exponent
+            value = value.replace("e","E"); 
             return formatter.parse(value).doubleValue();
         } catch (ParseException pe) {
             throw new NumberFormatException(pe.getMessage());


### PR DESCRIPTION
Hi guys - these mods came about when someone noticed you cannot use lowercase "e" when using scientific notation.  Both upper and lowercase should be allowed.  See section titled "E notation" from the Wikipedia page:

http://en.wikipedia.org/wiki/Scientific_notation

But worse, the Change Range UI was not parsing input correctly, due to behavior of the Misc.parseNumber() method, which would take the first valid double and drop any characters after that.  As a result, something like:

1.2crud

would get parsed as 1.2, but:

1.2e-8 

would also get parsed as 1.2, instead of the correct scientific notation.

The mods I made will IMO correctly flag 1.2crud as invalid, and accept all correct forms of floating point numbers.
