### PR TITLE
Add Geopotential_isobaric alias for ECMWF grids

### DIFF
--- a/src/ucar/unidata/idv/resources/aliases.xml
+++ b/src/ucar/unidata/idv/resources/aliases.xml
@@ -108,7 +108,7 @@ The label is used  (if defined) for  the AliasEditor gui.
   <alias
      name="GP"
      label="Geopotential"
-     aliases="Geopotential"/>
+     aliases="Geopotential,Geopotential_isobaric"/>
   <alias
      name="ALTITUDE"
      label="Altitude"


### PR DESCRIPTION
ECMWF grids only natively contain "geopotential", so to display "geopotential height" you must use a derived quantity.  However, currently "geopotential height" does not appear as a derived quantity for ECMWF data sources.  This simply adds a "Geopotential_isobaric" alias so the derived quantity will show up properly.

To test, load an ECMWF grib file as a data source.  If you see "3D grid" -> "Derived" -> "Height from Geopotential (Geopotential_isobaric)" as an option, the fix is working.  An example file for testing is here:

ftp://ftp.ssec.wisc.edu/pub/incoming/ecmwf.grb

This is a fix for McV inquiry 1129:
http://dcdbs.ssec.wisc.edu/inquiry-v/?inquiry=1129

Thanks!
Mike
