### PR TITLE
Improved handling of identically-named formula parameters.

### DIFF
--- a/src/ucar/unidata/data/DataOperand.java
+++ b/src/ucar/unidata/data/DataOperand.java
@@ -83,6 +83,8 @@ public class DataOperand {
     /** Data categories */
     private List categories;
 
+    /** Data Choice associated with this operand. May be {@code null}. */
+    private DerivedDataChoice dataChoice;
 
     /** associated data */
     private Object data;
@@ -98,17 +100,18 @@ public class DataOperand {
      *
      */
     public DataOperand(String name) {
-        this(name, null);
+        this(null, name, null);
     }
 
     /**
-     * Create a new DataOperand
-     *
+     * Create a new DataOperand.
+     * 
+     * @param choice  Data choice associated with this operand. May be {@code null}.
      * @param name    name for this object
      * @param data    associated data
-     *
      */
-    public DataOperand(String name, Object data) {
+    public DataOperand(DerivedDataChoice choice, String name, Object data) {
+        this.dataChoice = choice;
         this.name = name;
         this.data = data;
         int idx1 = name.indexOf("[");
@@ -461,7 +464,24 @@ public class DataOperand {
         return timeIndices;
     }
 
-
+    /**
+     * Returns the Data Choice associated with this operand.
+     * 
+     * @return Either the associated data choice or {@code null}.
+     */
+    public DerivedDataChoice getDataChoice() {
+        return dataChoice;
+    }
+    
+    /**
+     * Sets the Data Choice associated with this operand.
+     * 
+     * @param choice Associated data choice. May be {@code null}.
+     */
+    public void setDataChoice(DerivedDataChoice choice) {
+        dataChoice = choice;
+    }
+    
     /**
      * Test
      *

--- a/src/ucar/unidata/data/DerivedDataChoice.java
+++ b/src/ucar/unidata/data/DerivedDataChoice.java
@@ -287,6 +287,7 @@ public class DerivedDataChoice extends ListDataChoice {
     /**
      * A utility to to add (uniquely) the given opName into the list of ops.
      *
+     * @param choice        The data choice associated with the operand being created.
      * @param opName        The operand name (e.g., D1)
      * @param data          The data associated  with the operand.
      * @param operands      The list of operand ({@link DataOperand}) objects.
@@ -295,8 +296,8 @@ public class DerivedDataChoice extends ListDataChoice {
      * @return The instance of the {@link DataOperand} that holds
      *         the opName/data pair.
      */
-    private static DataOperand addOperand(String opName, Object data,
-                                          List operands, Hashtable opsSoFar) {
+    private static DataOperand addOperand(DerivedDataChoice choice, String opName, Object data,
+            List operands, Hashtable opsSoFar) {
         DataOperand dataOperand = (DataOperand) opsSoFar.get(opName);
         if (dataOperand != null) {
             if ( !dataOperand.isBound()) {
@@ -304,13 +305,11 @@ public class DerivedDataChoice extends ListDataChoice {
             }
             return dataOperand;
         }
-        dataOperand = new DataOperand(opName, data);
+        dataOperand = new DataOperand(choice, opName, data);
         opsSoFar.put(opName, dataOperand);
         operands.add(dataOperand);
         return dataOperand;
     }
-
-
 
     /**
      *  Add the given operand op into the list of ops if it has not been
@@ -427,7 +426,7 @@ public class DerivedDataChoice extends ListDataChoice {
         for (int i = 0; i < childrenChoices.size(); i++) {
             DataChoice dc = (DataChoice) childrenChoices.get(i);
             if (dc instanceof UserDataChoice) {
-                DataOperand operand = new DataOperand(dc.getName(),
+                DataOperand operand = new DataOperand(this, dc.getName(),
                                           ((UserDataChoice) dc).getValue());
                 allUserOperands.add(operand);
                 if ( !operand.isBound()) {
@@ -475,11 +474,11 @@ public class DerivedDataChoice extends ListDataChoice {
             String     opName = dc.getName();
             if (dc instanceof UnboundDataChoice) {
                 //                System.err.println ("unbound choice");
-                addOperand(opName, null, operands, operandsSoFar);
+                addOperand(this, opName, null, operands, operandsSoFar);
             } else if (dc instanceof UserDataChoice) {
                 //                System.err.println ("UDC");
                 UserDataChoice userChoice = (UserDataChoice) dc;
-                addOperand(alias, userChoice.getValue(), operands,
+                addOperand(this, alias, userChoice.getValue(), operands,
                            operandsSoFar);
                 if ( !userChoice.persistent) {
                     userChoice.setValue(null);
@@ -487,10 +486,10 @@ public class DerivedDataChoice extends ListDataChoice {
             } else {
                 //Here, put the DataChoice in as the  data (sort of as a place holder for later).
                 //                System.err.println ("addOperand " + opName + " alias = " + alias );
-                addOperand(opName, dc, operands, operandsSoFar);
+                addOperand(this, opName, dc, operands, operandsSoFar);
                 if (userSelectedChoices.get(alias) == null) {
                     //                    System.err.println ("addOperand-alias " + alias);
-                    addOperand(alias, dc, operands, operandsSoFar);
+                    addOperand(this, alias, dc, operands, operandsSoFar);
                 }
             }
         }
@@ -503,7 +502,7 @@ public class DerivedDataChoice extends ListDataChoice {
         for (int i = 0; i < nonUserOperands.size(); i++) {
             DataOperand operand = (DataOperand) nonUserOperands.get(i);
             //            System.err.println ("addOperand-nonUser ");
-            addOperand(operand.getName(), null, operands, operandsSoFar);
+            addOperand(this, operand.getName(), null, operands, operandsSoFar);
         }
 
 

--- a/src/ucar/unidata/idv/ui/IdvUIManager.java
+++ b/src/ucar/unidata/idv/ui/IdvUIManager.java
@@ -5662,13 +5662,33 @@ public class IdvUIManager extends IdvManager {
             if (fieldType == null) {
                 fieldType = FIELDTYPE_TEXT;
             }
-            String label         = operand.getLabel();
-            Object dflt          = operand.getUserDefault();
-            Object cacheKey      = Misc.newList(label, fieldType);
-            Object cachedOperand = operandCache.get(cacheKey);
+            
+            DerivedDataChoice formula = operand.getDataChoice();
+            String description        = operand.getDescription();
+            if (formula != null) {
+                description = formula.toString();
+            }
+            
+            String label            = operand.getLabel();
+            Object dflt             = operand.getUserDefault();
+            Object cacheKeyNewStyle = Misc.newList(description, label, fieldType);
+            Object cacheKey         = Misc.newList(label, fieldType);
+            
+            Object cachedOperand = null;
+            boolean oldStyle = operandCache.containsKey(cacheKey);
+            boolean newStyle = operandCache.containsKey(cacheKeyNewStyle);
+            
+            // if new style, always use that and ignore old style
+            // if no new style, proceed as before.
+            if (newStyle) {
+                cachedOperand = operandCache.get(cacheKeyNewStyle);
+            } else if (oldStyle) {
+                cachedOperand = operandCache.get(cacheKey);
+            }
             if (cachedOperand != null) {
                 dflt = cachedOperand;
             }
+            
             JCheckBox cbx = new JCheckBox("", operand.isPersistent());
             persistentCbxs.add(cbx);
             JComponent field     = null;
@@ -5781,11 +5801,18 @@ public class IdvUIManager extends IdvManager {
         }
         List values = new ArrayList();
         for (int i = 0; i < userOperands.size(); i++) {
-            DataOperand operand    = (DataOperand) userOperands.get(i);
-            String      label      = operand.getLabel();
-            Object      field      = fields.get(i);
-            Object      value      = null;
-            Object      cacheValue = null;
+            DataOperand       operand     = (DataOperand) userOperands.get(i);
+            String            description = operand.getDescription();
+            DerivedDataChoice formula     = operand.getDataChoice();
+            String            label       = operand.getLabel();
+            Object            field       = fields.get(i);
+            Object            value       = null;
+            Object            cacheValue  = null;
+            
+            if (formula != null) {
+                description = formula.toString();
+            }
+            
             if (field instanceof JTextComponent) {
                 value = ((JTextComponent) field).getText().trim();
             } else if (field instanceof JCheckBox) {
@@ -5808,13 +5835,13 @@ public class IdvUIManager extends IdvManager {
             if (fieldType == null) {
                 fieldType = "text";
             }
-            Object cacheKey = Misc.newList(label, fieldType);
+            
+            Object cacheKey = Misc.newList(description, label, fieldType);
             operandCache.put(cacheKey, cacheValue);
             values.add(new UserOperandValue(value, cbx.isSelected()));
         }
         getStore().putEncodedFile("operandcache.xml", operandCache);
         return values;
-
     }
 
 


### PR DESCRIPTION
Hi everyone,

@mhiley pointed out to me that if a parameter name is shared by more than one formula, the user input written out to `operandcache.xml` will be associated with every parameter using that name.

This is due to the way the operand cache key is constructed. Currently, it uses the following:

`cache[(parameter_name, parameter_type)] = <VALUE>`

The attached code simply changes the key to this:

`cache[(formula_description, parameter_name, parameter_type)] = <VALUE>`

This was a little problematic in that a `DataOperand` had no way of knowing which formula it is associated with, so I ended up having to modify both `DataOperand` and `DerivedDataChoice`. While all of that should be obvious from the diffs, I wanted to explicitly mention it because I feel like it is a little too fragile…though it has worked fine in my testing.
