### PR TITLE
JFileChooser on OS X may revert to previous directory upon changing file format.

### DIFF
--- a/src/ucar/unidata/util/FileManager.java
+++ b/src/ucar/unidata/util/FileManager.java
@@ -196,9 +196,12 @@ public class FileManager {
             System.out.println("OS ==  " + osName + " def =" + defDir);
         }
         boolean isWindose = (0 <= osName.indexOf("Windows"));
+        boolean isMac = (System.getProperty("mrj.version") != null);
 
         if (isWindose) {
             defaultDirs.add("C:/");
+        } else if (isMac) {
+            defaultDirs.add(System.getProperty("user.home"));
         }
 
         File            defaultDirectory = findDefaultDirectory(defaultDirs);
@@ -273,7 +276,10 @@ public class FileManager {
                             }
                         }
                         if (newFileName != null) {
-                            chooser.setSelectedFile(new File(newFileName));
+                            File newFile = new File(newFileName);
+                            if (newFile.equals(lastFile)) {
+                                chooser.setSelectedFile(newFile);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
1. Go to `File > Open…`.
2. Browse to some directory that does not have any IDV files (ISL, bundles, or JNLP).
3. Pick either the ISL, bundle, or JNLP file format.

I end up in the parent directory of the last directory I opened. Note that if you pick `All Files`, everything seems to work as expected.
