### PR TITLE
Globe View Properties should close after "OK".

### DIFF
--- a/src/ucar/unidata/idv/MapViewManager.java
+++ b/src/ucar/unidata/idv/MapViewManager.java
@@ -2394,10 +2394,11 @@ public class MapViewManager extends NavigatedViewManager {
         if ( !super.applyProperties()) {
             return false;
         }
-        if (globeBackgroundDisplayable != null) {
+        if (useGlobeDisplay && (globeBackgroundDisplayable != null)) {
             globeBackgroundColor = globeBackgroundColorComp.getBackground();
             globeBackgroundLevel = globeBackgroundLevelSlider.getValue();
             setGlobeBackground((GlobeDisplay) getMapDisplay());
+            return true;
         }
         return applyAxisVisibility();
     }


### PR DESCRIPTION
This is pretty easy to reproduce. Just create a globe view, open up the `View>Properties" and click the "OK" button. The window probably didn't go away.

It looks as though globe displays always lack a `latLonScaleWidget`, causing the check in `MapViewManager.applyAxisVisibility()` to always fail. This then "bubbles up" the call stack to the `ActionListener` within `ViewManager.showPropertiesDialog()` and eventually trips that early exit logic, causing the dialog to not close as expected.

This should fix Inquiry #1507.
