### PR TITLE
Renaming NavigatedDisplay's "rotate*" fields.

### DIFF
--- a/src/ucar/unidata/view/geoloc/NavigatedDisplay.java
+++ b/src/ucar/unidata/view/geoloc/NavigatedDisplay.java
@@ -181,13 +181,13 @@ public abstract class NavigatedDisplay extends DisplayMaster {
     private int rotateTimeStamp = 0;
 
     /** rotate x flag */
-    private double rotateX = 0;
+    private double rotateXMultiplier = 0;
 
     /** rotate y flag */
-    private double rotateY = -1;
+    private double rotateYMultiplier = -1;
 
     /** rotate z flag */
-    private double rotateZ = 0;
+    private double rotateZMultiplier = 0;
 
     /** flag for perspective view */
     private boolean isPerspective = true;
@@ -365,9 +365,9 @@ public abstract class NavigatedDisplay extends DisplayMaster {
      * @param rotz  z rotation
      */
     public void setRotationMultiplierMatrix(double rotx, double roty, double rotz) {
-        rotateX = rotx;
-        rotateY = roty;
-        rotateZ = rotz;
+        rotateXMultiplier = rotx;
+        rotateYMultiplier = roty;
+        rotateZMultiplier = rotz;
     }
 
     /**
@@ -2265,7 +2265,8 @@ public abstract class NavigatedDisplay extends DisplayMaster {
             t2 = mouseBehavior.make_translate(transA[0], transA[1], transA[2]);
         }
 
-        double[] t1 = display.make_matrix(rotateX / scale, rotateY / scale, rotateZ / scale, 1.0, 0.0, 0.0, 0.0);
+        double[] t1 = display.make_matrix(rotateXMultiplier / scale, rotateYMultiplier / scale, 
+                rotateZMultiplier / scale, 1.0, 0.0, 0.0, 0.0);
 
         t1 = mouseBehavior.multiply_matrix(t1, myMatrix);
 


### PR DESCRIPTION
Hello again!
##### TL;DR:

This isn't applicable to the IDV (unless launched with `-Dpython.security.respectJavaAccessibility=false`), but the changes appear harmless in my testing and it would instantly resolve a problem for a McV user.
##### Gory Details

Owing to the Python language spec, Jython cannot distinguish between fields and methods that share the same name. `NavigatedDisplay` extending `DisplayMaster` results in Jython essentially overwriting `DisplayMaster.rotate*()` methods with `NavigatedDisplay.rotate*` fields.

The end result is that the `rotate*()` methods can no longer be called via Jython when the `python.security.respectJavaAccessibility` property is set to `false`. This can be verified by running the following Jython from the IDV's Jython Shell (remember to set the property!):

``` python
idv.getVMManager().getLastActiveViewManager().getMaster().rotateX(10.)
```

The most straightforward fix appears to be simply renaming the fields.
