### PR TITLE
Refactor initReadout for component group compatibility.

### DIFF
--- a/src/ucar/unidata/idv/NavigatedViewManager.java
+++ b/src/ucar/unidata/idv/NavigatedViewManager.java
@@ -362,12 +362,10 @@ public abstract class NavigatedViewManager extends ViewManager {
      * @param w window for readout
      */
     private void initReadout(IdvWindow w) {
-        if ((w != null) && (readout != null)) {
-
-            // GuiUtils.setFixedWidthFont(w.getMsgLabel());
+        if (w != null) {
             readout.setValueDisplay(w.getMsgLabel());
-            setReadoutFormat();
         }
+        setReadoutFormat();
     }
 
     /**
@@ -714,7 +712,7 @@ public abstract class NavigatedViewManager extends ViewManager {
     protected void verticalRangeChanged() {}
 
     /**
-     * Set the format for the curso readout
+     * Set the format for the cursor readout.
      */
     protected void setReadoutFormat() {
         if (readout != null) {


### PR DESCRIPTION
This reworks the logic within initReadout so that setReadoutFormat is always called, even if the IdvWindow passed to initReadout is null (as seems to be the case when dealing with component groups).

Always calling setReadoutFormat like this is safe because it always does an internal check for whether or not the readout field is null.
