### PR TITLE
[1399] Explicit check for null 'time' to prevent Exception when only one time

### DIFF
--- a/src/ucar/unidata/idv/control/GriddedSoundingControl.java
+++ b/src/ucar/unidata/idv/control/GriddedSoundingControl.java
@@ -270,7 +270,7 @@ public class GriddedSoundingControl extends AerologicalSoundingControl {
     protected void timeChanged(Real time) {
         try {
             super.timeChanged(time);
-            dataNode.setTime(new DateTime(time));
+            if (time != null) dataNode.setTime(new DateTime(time));
             if (getProfilesVisibility()) {
                 AnimationWidget aniWidget = this.getAnimationWidget();
                 int idx = 0;


### PR DESCRIPTION
 tested on nightly with gridded data and RAOBs.
