### PR TITLE
Fix ability of writeImage() to use 8-bit characters in labels

### DIFF
--- a/src/ucar/unidata/xml/XmlUtil.java
+++ b/src/ucar/unidata/xml/XmlUtil.java
@@ -1566,7 +1566,7 @@ public abstract class XmlUtil {
         MyErrorHandler errorHandler = new MyErrorHandler();
         builder.setErrorHandler(errorHandler);
         try {
-            return builder.parse(new ByteArrayInputStream(xml.getBytes()));
+            return builder.parse(new ByteArrayInputStream(xml.getBytes("UTF-8")));
         } catch (Exception exc) {
             //            System.err.println("OOps:" + xml);
             throw new IllegalStateException("Error parsing xml: "


### PR DESCRIPTION
The only change here is to explicitly getBytes() with UTF-8 encoding for the ByteArrayInputStream for the parser to deal with.  This allows character like mu (µ) to be used for the text label on images.  Without this, one gets a parsing error...
