### PR TITLE
Free drawing and Front drawing have separate tables and column labels [1536]

### DIFF
--- a/src/ucar/unidata/idv/control/DrawingControl.java
+++ b/src/ucar/unidata/idv/control/DrawingControl.java
@@ -2647,7 +2647,7 @@ public class DrawingControl extends DisplayControlImpl {
      * @author IDV Development Team
      * @version $Revision: 1.145 $
      */
-    private class GlyphTable extends JTable {
+    public class GlyphTable extends JTable {
 
         /** table model */
         GlyphTableModel myTableModel;
@@ -2810,7 +2810,7 @@ public class DrawingControl extends DisplayControlImpl {
      * @author IDV Development Team
      * @version $Revision: 1.145 $
      */
-    private class GlyphTableModel extends AbstractTableModel {
+    public class GlyphTableModel extends AbstractTableModel {
 
         /** Ignore any events */
         boolean ignoreChanges = false;
@@ -2922,6 +2922,9 @@ public class DrawingControl extends DisplayControlImpl {
                 return "Type";
             }
             if (column == 2) {
+                return "Coordinates";
+            }
+            if (column == 3) {
                 return "Properties";
             }
             if ( !editable) {

--- a/src/ucar/unidata/idv/control/FrontDrawingControl.java
+++ b/src/ucar/unidata/idv/control/FrontDrawingControl.java
@@ -1,0 +1,61 @@
+package ucar.unidata.idv.control;
+
+import java.awt.Dimension;
+
+import javax.swing.JComponent;
+import javax.swing.JScrollPane;
+
+import ucar.unidata.util.GuiUtils;
+
+/**
+ * Had to extend DrawingControl since JTable for Front drawing 
+ * has a different structure (less columns, slightly different names).
+ * 
+ * @author tommyj
+ *
+ */
+
+public class FrontDrawingControl extends DrawingControl {
+    
+    /**
+     * Make the jtable panel
+     *
+     * @return jtable panel
+     */
+    protected JComponent doMakeTablePanel() {
+        glyphTableModel = new FrontGlyphTableModel();
+        glyphTable      = new GlyphTable(glyphTableModel);
+        JScrollPane sp = GuiUtils.makeScrollPane(glyphTable, 200, 100);
+        sp.setPreferredSize(new Dimension(200, 100));
+        JComponent tablePanel = GuiUtils.center(sp);
+        glyphTable.selectionChanged();
+        return tablePanel;
+    }
+    
+    public class FrontGlyphTableModel extends GlyphTableModel {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        /**
+         * col name
+         *
+         * @param column column
+         *
+         * @return col name
+         */
+        public String getColumnName(int column) {
+            if (column == 0) {
+                return "Name";
+            }
+            if (column == 1) {
+                return "Type";
+            }
+            if (column == 2) {
+                return "Properties";
+            }
+            return "";
+        }
+        
+    }
+    
+}

--- a/src/ucar/unidata/idv/resources/controls.xml
+++ b/src/ucar/unidata/idv/resources/controls.xml
@@ -1085,7 +1085,7 @@ Since this is confusing and needs more work lets remove this for now
   <control
      id="frontdrawingcontrol"
      categories="fronts"
-     class="ucar.unidata.idv.control.DrawingControl"
+     class="ucar.unidata.idv.control.FrontDrawingControl"
      label="Front Display"
      displaycategory="General"
      properties="windowVisible=true;showInTabs=true">


### PR DESCRIPTION
Hi guys - 

This fixes a problem where Free Drawing control and Front Drawing controls where sharing the same JTable class (an extension of AbstractTableModel).  As a result the tables were mis-labeled.  We just gave the Front control its own class, which returns the proper column label.  Me, Jon, and Mike looked at this together all all agreed it's a decent, clean solution.

Both pics below show corrected behavior, you can compare with current behavior.

Free drawing: Displays -> Special -> Drawing Control

Front drawing: Data Choosers -> Fronts -> Add Source

![screen shot 2014-03-06 at 3 35 02 pm](https://f.cloud.github.com/assets/2334847/2351058/19628538-a578-11e3-8bc5-e63117869295.png)

![screen shot 2014-03-06 at 3 34 24 pm](https://f.cloud.github.com/assets/2334847/2351059/20557d5a-a578-11e3-9bc6-b2b60119343a.png)
