### PR TITLE
Removed redundant "Properties" menu item in the Cross Section control.

### DIFF
--- a/src/ucar/unidata/idv/CrossSectionViewManager.java
+++ b/src/ucar/unidata/idv/CrossSectionViewManager.java
@@ -128,9 +128,6 @@ public class CrossSectionViewManager extends ViewManager {
         showControlMenu = false;
         super.initializeViewMenu(viewMenu);
         viewMenu.add(makeColorMenu());
-        viewMenu.addSeparator();
-        viewMenu.add(GuiUtils.makeMenuItem("Properties", this,
-                                           "showPropertiesDialog"));
     }
 
 


### PR DESCRIPTION
Hi everyone,

This is a fix for [McV Inquiry 1400](http://dcdbs.ssec.wisc.edu/inquiry-v/?inquiry=1400). To recap:

> When you create a cross section display, there are two menu items that take you
> to the Properties of the Cross Section:
>
>1. Edit > Properties > Cross Section
>2. View > Cross Section > Properties

This commit removes that second menu item.