### PR TITLE
Add a method for clearing auto display args.

### DIFF
--- a/src/ucar/unidata/idv/ArgsManager.java
+++ b/src/ucar/unidata/idv/ArgsManager.java
@@ -49,7 +49,7 @@ import java.io.File;
 import java.rmi.RemoteException;
 
 import java.util.ArrayList;
-
+import java.util.Collections;
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.List;


### PR DESCRIPTION
Hi everyone!

This change is pretty straightforward–all it does is allow code outside of `ucar.unidata.idv` to clear out `initParams` and `initDisplays`. I thought about simply making those fields protected, but this approach seems a little more tidy.

Jon
