### PR TITLE
Remove restriction on map label length [1484]

### DIFF
--- a/src/ucar/unidata/ui/MapPanel.java
+++ b/src/ucar/unidata/ui/MapPanel.java
@@ -41,6 +41,7 @@ import javax.swing.JPanel;
 
 import ucar.unidata.gis.maps.MapData;
 import ucar.unidata.util.GuiUtils;
+import ucar.unidata.util.StringUtil;
 
 /**
  * Panel to hold map gui items for one map
@@ -51,10 +52,8 @@ public class MapPanel extends JPanel {
     /** This holds the data that describes the map */
     private MapData mapData;
 
-
     /** The visibility cbx */
     private JCheckBox shownCbx;
-
 
     /** The line width box */
     private JComboBox widthBox;
@@ -73,6 +72,9 @@ public class MapPanel extends JPanel {
 
     /** Are we updating the UI */
     private boolean updatingUI = false;
+    
+    /** Limit on map label string length */
+    private static final int MAP_LABEL_MAX_LENGTH = 35;
 
     /**
      * Create the MapPanel with the given MapData
@@ -104,15 +106,31 @@ public class MapPanel extends JPanel {
         setLayout(new GridLayout(1, 2));
         setAlignmentY(Component.CENTER_ALIGNMENT);
         String name = mapData.getDescription();
-
+        String longName = name;
+        boolean truncatedName = false;
+        
+        // TJJ Apr 2014
+        if (name.length() > MAP_LABEL_MAX_LENGTH) {
+        	// Pad with ellipses if we exceeded max length
+            name = name.substring(0, (MAP_LABEL_MAX_LENGTH - 3));
+            name = StringUtil.padRight(name, MAP_LABEL_MAX_LENGTH, ".");
+            truncatedName = true;
+        }
+        
         shownCbx = new JCheckBox(name, mapData.getVisible());
+
         Font lblFont = shownCbx.getFont();
         Font monoFont = new Font("Monospaced", lblFont.getStyle(),
                                  lblFont.getSize());
         shownCbx.setFont(monoFont);
 
-
+        // Tooltip for most rows
         shownCbx.setToolTipText("Toggle visibility");
+        
+        // For truncated rows, tooltip is full description of map name
+        if (truncatedName) {
+        	shownCbx.setToolTipText(longName);
+        }
 
         shownCbx.setHorizontalAlignment(JCheckBox.LEFT);
         add(shownCbx);


### PR DESCRIPTION
Guys - the only relevant bit is the part removing the restriction on name length at 30 chars. The rest is cosmetic.  We need this because our hi-res map label is otherwise truncated in the display.  The display is all within a scrollpane so if ever there was need for more room, it should expand fine, and we tested this.

Here are before and after pics so you can see the effect of this minor change.

Before: (label truncated)

![screen shot 2014-04-10 at 2 36 26 pm](https://cloud.githubusercontent.com/assets/2334847/2672498/7a116072-c0e7-11e3-8481-b74c0f8c24fa.png)

After: (label fits fine)

![screen shot 2014-04-10 at 2 35 03 pm](https://cloud.githubusercontent.com/assets/2334847/2672502/898e9830-c0e7-11e3-9db3-b80bf2273e19.png)
