### PR TITLE
display control bug: "light gray" option doesn't work

### DIFF
--- a/src/ucar/unidata/util/GuiUtils.java
+++ b/src/ucar/unidata/util/GuiUtils.java
@@ -689,7 +689,7 @@ public class GuiUtils extends LayoutUtil {
             }
             return new Color(Integer.decode(s).intValue());
         } catch (Exception e) {
-            s = s.toLowerCase();
+            s = value.toLowerCase();
             for (int i = 0; i < COLORNAMES.length; i++) {
                 if (s.equals(COLORNAMES[i])) {
                     return COLORS[i];


### PR DESCRIPTION
Hey guys,

There's a bug in display controls with a selectable color:

> Create a display of vectors or streamlines from model data. In the Layer Controls, there is an option for Color.  One of the colors listed here is Light Gray. When you select Light Gray, it does not work, and reverts to Gray. There are no error messages.

This is apparently due to logic in GuiUtils.decodeColor, which does some string splitting on spaces to try and assemble RGB values... then if this part fails, it falls back to a pre-defined COLORNAMES list... but, it uses the string value that has already been split up, instead of the original color name method argument, and therefore fails on color names with a space.  So, by using "value" instead of "s" when falling back to COLORNAMES, we fix the "Light Gray" bug.

This is a fix for [McIDAS-V inquiry 1372](http://mcidas.ssec.wisc.edu/inquiry-v/?inquiry=1372)

[1372] 
