### PR TITLE
fix ParamDefaults bug

### DIFF
--- a/src/ucar/unidata/idv/ui/ParamDefaultsEditor.java
+++ b/src/ucar/unidata/idv/ui/ParamDefaultsEditor.java
@@ -1521,6 +1521,11 @@ public class ParamDefaultsEditor extends IdvManager implements ActionListener {
             if (canonicalName != null) {
                 info = (ParamInfo) StringUtil.findMatch(
                     canonicalName.toLowerCase(), paramInfos, null);
+                if (info == null) {
+                    // try one more time without doing toLowerCase
+                    info = (ParamInfo) StringUtil.findMatch(
+                            canonicalName, paramInfos, null);
+                }
             }
         }
         return info;


### PR DESCRIPTION
Hi guys,

We were having some issues with Parameter Defaults...we had a case where the default color table was being respected, but not default color table _range_.

Anyway, I tracked this down to an issue in `ParamDefaultsEditor.getParamInfo`...there's a simple issue with lower-case'd strings not matching up with strings in the `paramInfos` list.  So to fix our problem I just add another search with the non-lower-case'd string.

This should fix [McIDAS-V inquiry 1371](http://mcidas.ssec.wisc.edu/inquiry-v/index.php?inquiry=1371) 
[1371]
