### PR TITLE
Replace deprecated "show" calls with "setVisible".

### DIFF
--- a/src/ucar/unidata/collab/PropertiedThing.java
+++ b/src/ucar/unidata/collab/PropertiedThing.java
@@ -307,7 +307,7 @@ public abstract class PropertiedThing extends SharableImpl implements PropertyCh
                 }
                 propertiesDialog.setLocation(loc);
             }
-            propertiesDialog.show();
+            propertiesDialog.setVisible(true);
             propertiesDialog = null;
             return true;
         } catch (Exception exc) {

--- a/src/ucar/unidata/data/CacheDataSource.java
+++ b/src/ucar/unidata/data/CacheDataSource.java
@@ -171,7 +171,7 @@ public class CacheDataSource extends DataSourceImpl {
                     progressBar), 5));
             dialog.pack();
             dialog.setLocation(200, 200);
-            dialog.show();
+            dialog.setVisible(true);
 
 
             List holders = writeToCache(progressBar);

--- a/src/ucar/unidata/data/gis/Test.java
+++ b/src/ucar/unidata/data/gis/Test.java
@@ -146,7 +146,7 @@ public class Test {
         });
         frame.getContentPane().add("South", save);
         frame.pack();
-        frame.show();
+        frame.setVisible(true);
     }
 }
 

--- a/src/ucar/unidata/idv/IdvPersistenceManager.java
+++ b/src/ucar/unidata/idv/IdvPersistenceManager.java
@@ -3363,7 +3363,7 @@ public class IdvPersistenceManager extends IdvManager implements PrototypeManage
 
         dialog.getContentPane().add(comp);
         dialog.pack();
-        dialog.show();
+        dialog.setVisible(true);
         if (result[0] == null) {
             return false;
         }

--- a/src/ucar/unidata/idv/ViewManager.java
+++ b/src/ucar/unidata/idv/ViewManager.java
@@ -1340,7 +1340,7 @@ public class ViewManager extends SharableImpl implements ActionListener,
         if (newOne) {
             GuiUtils.showDialogNearSrc(viewMenu, propertiesDialog);
         } else {
-            propertiesDialog.show();
+            propertiesDialog.setVisible(true);
         }
 
         propertiesDialogShown = true;

--- a/src/ucar/unidata/idv/chooser/TimesChooser.java
+++ b/src/ucar/unidata/idv/chooser/TimesChooser.java
@@ -1656,7 +1656,7 @@ public class TimesChooser extends IdvChooser {
             //            loc.y += timelineBtn.getSize().height;
             dialog.setLocation(loc);
             GuiUtils.positionAndFitToScreen(dialog, dialog.getBounds());
-            dialog.show();
+            dialog.setVisible(true);
             if (ok[0]) {
                 selected = new ArrayList();
                 for (Date dttm :

--- a/src/ucar/unidata/idv/collab/CaptureManager.java
+++ b/src/ucar/unidata/idv/collab/CaptureManager.java
@@ -683,7 +683,7 @@ public class CaptureManager {
             captureWindow = new JFrame("Capture Window");
             GuiUtils.packWindow(captureWindow, captureContents, true);
         }
-        captureWindow.show();
+        captureWindow.setVisible(true);
         captureWindow.toFront();
     }
 

--- a/src/ucar/unidata/idv/control/DisplayControlImpl.java
+++ b/src/ucar/unidata/idv/control/DisplayControlImpl.java
@@ -5699,7 +5699,7 @@ public abstract class DisplayControlImpl extends DisplayControlBase implements D
         if (f != null) {
             GuiUtils.showDialogNearSrc(f, propertiesDialog);
         } else {
-            propertiesDialog.show();
+            propertiesDialog.setVisible(true);
         }
     }
 

--- a/src/ucar/unidata/idv/control/DisplaySettingsDialog.java
+++ b/src/ucar/unidata/idv/control/DisplaySettingsDialog.java
@@ -298,7 +298,7 @@ public class DisplaySettingsDialog {
             GuiUtils.showDialogNearSrc(f, dialog);
         } else {
             dialog.setLocation(new Point(200, 200));
-            dialog.show();
+            dialog.setVisible(true);
         }
     }
 

--- a/src/ucar/unidata/idv/control/drawing/TextGlyph.java
+++ b/src/ucar/unidata/idv/control/drawing/TextGlyph.java
@@ -638,7 +638,7 @@ public class TextGlyph extends DrawingGlyph {
                 JDialog dialog = (JDialog) comps[1];
                 if ( !dialog.isVisible()) {
                     dialog.setLocation(new Point(x, y));
-                    dialog.show();
+                    dialog.setVisible(true);
                 } else {
                     dialog.toFront();
                 }

--- a/src/ucar/unidata/idv/control/storm/StormTrackControl.java
+++ b/src/ucar/unidata/idv/control/storm/StormTrackControl.java
@@ -1629,7 +1629,7 @@ public class StormTrackControl extends DisplayControlImpl {
                         } catch (Exception exc) {
                             //Ignore this incase the component isn't being shown
                         }
-                        errorWindow.show();
+                        errorWindow.setVisible(true);
                     }
                     errors = errors + "Error " + currentMessage + "<br>";
                     yds.setStatus("Error:" + currentMessage);

--- a/src/ucar/unidata/idv/flythrough/Flythrough.java
+++ b/src/ucar/unidata/idv/flythrough/Flythrough.java
@@ -2557,7 +2557,7 @@ public class Flythrough extends SharableImpl implements PropertyChangeListener,
         }
         setAnimationTimes();
         if (frame != null) {
-            frame.show();
+            frame.setVisible(true);
         }
     }
 

--- a/src/ucar/unidata/idv/ui/BundleTree.java
+++ b/src/ucar/unidata/idv/ui/BundleTree.java
@@ -440,10 +440,13 @@ public class BundleTree extends DndTree {
 
 
     /**
-     * Show the window
+     * Show or hide {@link #frame}.
+     *
+     * @param visible if {@code true}, show {@code frame}. Otherwise hides
+     * {@code frame}.
      */
-    public void show() {
-        frame.show();
+    @Override public void setVisible(boolean visible) {
+        frame.setVisible(visible);
     }
 
 

--- a/src/ucar/unidata/idv/ui/CursorReadoutWindow.java
+++ b/src/ucar/unidata/idv/ui/CursorReadoutWindow.java
@@ -184,7 +184,7 @@ public class CursorReadoutWindow {
             window = new JWindow(parent);
             window.pack();
             setWindowLocation();
-            window.show();
+            window.setVisible(true);
         }
         double[] box =
             vm.getNavigatedDisplay().getSpatialCoordinatesFromScreen(

--- a/src/ucar/unidata/idv/ui/DataControlDialog.java
+++ b/src/ucar/unidata/idv/ui/DataControlDialog.java
@@ -821,7 +821,7 @@ public class DataControlDialog implements ActionListener {
         cpane.add("Center", GuiUtils.inset(contents, 5));
         dialog.setLocation(x, y);
         dialog.pack();
-        dialog.show();
+        dialog.setVisible(true);
     }
 
     /**

--- a/src/ucar/unidata/idv/ui/DataTreeDialog.java
+++ b/src/ucar/unidata/idv/ui/DataTreeDialog.java
@@ -236,7 +236,7 @@ public class DataTreeDialog implements ActionListener {
             dialog.setLocation(50, 50);
         }
         dialog.pack();
-        dialog.show();
+        dialog.setVisible(true);
     }
 
 

--- a/src/ucar/unidata/idv/ui/IdvLegend.java
+++ b/src/ucar/unidata/idv/ui/IdvLegend.java
@@ -233,7 +233,7 @@ public abstract class IdvLegend implements Removable {
             floatLegend();
         } else if (floatFrame != null) {
             floatFrame.setState(Frame.NORMAL);
-            floatFrame.show();
+            floatFrame.setVisible(true);
         }
         setFloatToolTip();
     }
@@ -392,7 +392,7 @@ public abstract class IdvLegend implements Removable {
         floatFrame.getContentPane().add(getContents());
         floatFrame.pack();
         floatFrame.setLocation(lastLocation);
-        floatFrame.show();
+        floatFrame.setVisible(true);
         setFloatToolTip();
     }
 

--- a/src/ucar/unidata/idv/ui/IdvSplash.java
+++ b/src/ucar/unidata/idv/ui/IdvSplash.java
@@ -228,7 +228,7 @@ public class IdvSplash extends JWindow {
                     Dimension ss =
                         Toolkit.getDefaultToolkit().getScreenSize();
                     d.setLocation(ss.width / 2 - 100, ss.height / 2 - 100);
-                    d.show();
+                    d.setVisible(true);
                 }
             }
         });
@@ -285,7 +285,7 @@ public class IdvSplash extends JWindow {
         ucar.unidata.util.Msg.translateTree(this);
 
 
-        show();
+        setVisible(true);
         toFront();
 
 

--- a/src/ucar/unidata/idv/ui/IdvUIManager.java
+++ b/src/ucar/unidata/idv/ui/IdvUIManager.java
@@ -3065,7 +3065,7 @@ public class IdvUIManager extends IdvManager {
             tree = new BundleTree(this, bundleType);
             bundleTrees.put(key, tree);
         }
-        tree.show();
+        tree.setVisible(true);
     }
 
 

--- a/src/ucar/unidata/idv/ui/ImageGenerator.java
+++ b/src/ucar/unidata/idv/ui/ImageGenerator.java
@@ -5660,7 +5660,7 @@ public class ImageGenerator extends IdvManager {
                 JFrame frame = GuiUtils.getFrame(viewManager.getContents());
                 if (frame != null) {
                     LogUtil.registerWindow(frame);
-                    frame.show();
+                    frame.setVisible(true);
                     GuiUtils.toFront(frame);
                     frame.setLocation(50, 50);
                     Misc.sleep(50);
@@ -5695,7 +5695,7 @@ public class ImageGenerator extends IdvManager {
                         GuiUtils.getFrame(viewManager.getContents());
                     if (frame != null) {
                         LogUtil.registerWindow(frame);
-                        frame.show();
+                        frame.setVisible(true);
                         GuiUtils.toFront(frame);
                         frame.setLocation(50, 50);
                         Misc.sleep(50);

--- a/src/ucar/unidata/ui/ComponentGroup.java
+++ b/src/ucar/unidata/ui/ComponentGroup.java
@@ -1111,7 +1111,7 @@ public class ComponentGroup extends ComponentHolder {
         f.setLocation(300, 300);
         f.getContentPane().add(g2.getContents());
         f.pack();
-        f.show();
+        f.setVisible(true);
     }
 
 

--- a/src/ucar/unidata/ui/DatasetUI.java
+++ b/src/ucar/unidata/ui/DatasetUI.java
@@ -657,7 +657,7 @@ public class DatasetUI {
 
             f.getContentPane().add(contents);
             f.pack();
-            f.show();
+            f.setVisible(true);
         } catch (Exception exc) {
             System.err.println("Error:" + exc);
         }

--- a/src/ucar/unidata/ui/GraphPaperLayout.java
+++ b/src/ucar/unidata/ui/GraphPaperLayout.java
@@ -1014,7 +1014,7 @@ public class GraphPaperLayout implements LayoutManager2 {
         f.getContentPane().add(editPanel.getContents());
         f.pack();
         f.setLocation(100, 100);
-        f.show();
+        f.setVisible(true);
 
     }
 

--- a/src/ucar/unidata/ui/HelpTipDialog.java
+++ b/src/ucar/unidata/ui/HelpTipDialog.java
@@ -271,7 +271,7 @@ public class HelpTipDialog extends JDialog implements HyperlinkListener {
         Dimension ss   = Toolkit.getDefaultToolkit().getScreenSize();
         setLocation(ss.width / 2 - size.width / 2,
                     ss.height / 2 - size.height / 2);
-        show();
+        setVisible(true);
     }
 
     /**

--- a/src/ucar/unidata/ui/MultiFrame.java
+++ b/src/ucar/unidata/ui/MultiFrame.java
@@ -132,7 +132,7 @@ public class MultiFrame {
     public void show() {
         JFrame theFrame = frame;
         if (theFrame != null) {
-            theFrame.show();
+            theFrame.setVisible(true);
         } else if (internalFrame != null) {
             internalFrame.show();
         }

--- a/src/ucar/unidata/ui/PanelWithFrame.java
+++ b/src/ucar/unidata/ui/PanelWithFrame.java
@@ -157,7 +157,7 @@ public class PanelWithFrame extends JPanel {
      */
     public void showFrame() {
         if (frame != null) {
-            frame.show();
+            frame.setVisible(true);
         }
     }
 

--- a/src/ucar/unidata/ui/PersistentDataDialog.java
+++ b/src/ucar/unidata/ui/PersistentDataDialog.java
@@ -265,7 +265,7 @@ public class PersistentDataDialog implements ActionListener {
      */
     public void show() {
         if (dialog != null) {
-            dialog.show();
+            dialog.setVisible(true);
         }
     }
 

--- a/src/ucar/unidata/ui/RovingProgress.java
+++ b/src/ucar/unidata/ui/RovingProgress.java
@@ -387,7 +387,7 @@ public class RovingProgress extends JPanel implements Removable {
         RovingProgress mm = new RovingProgress(Color.blue);
         f.getContentPane().add(mm);
         f.pack();
-        f.show();
+        f.setVisible(true);
         mm.start();
     }
 

--- a/src/ucar/unidata/ui/Timeline.java
+++ b/src/ucar/unidata/ui/Timeline.java
@@ -2773,7 +2773,7 @@ public class Timeline extends JPanel implements MouseListener,
             dialog.setLocation(new Point(200, 200));
         }
         dialogOK = false;
-        dialog.show();
+        dialog.setVisible(true);
         return dialogOK;
     }
 
@@ -2933,7 +2933,7 @@ public class Timeline extends JPanel implements MouseListener,
                 LayoutUtil.centerBottom(timeline.getContents(true), bottom));
             dialog.pack();
             dialog.setLocation(new Point(200, 200));
-            dialog.show();
+            dialog.setVisible(true);
 
         } catch (Throwable thr) {
             thr.printStackTrace();

--- a/src/ucar/unidata/ui/WindowHolder.java
+++ b/src/ucar/unidata/ui/WindowHolder.java
@@ -252,10 +252,10 @@ public abstract class WindowHolder implements ActionListener {
         }
         if (dialog != null) {
             dialog.setModal(modal);
-            dialog.show();
+            dialog.setVisible(true);
         }
         if (frame != null) {
-            frame.show();
+            frame.setVisible(true);
         }
 
         if (window != null) {

--- a/src/ucar/unidata/ui/XmlTree.java
+++ b/src/ucar/unidata/ui/XmlTree.java
@@ -1453,7 +1453,7 @@ public class XmlTree extends JTree {
             f.getContentPane().add(GuiUtils.makeScrollPane(t.getContents(),
                     200, 300));
             f.pack();
-            f.show();
+            f.setVisible(true);
         } catch (Exception exc) {
             System.err.println("Error:" + exc);
         }

--- a/src/ucar/unidata/ui/XmlUi.java
+++ b/src/ucar/unidata/ui/XmlUi.java
@@ -3018,7 +3018,7 @@ public class XmlUi implements ActionListener, ItemListener {
             f.getContentPane().add(xmlUi.getContents());
             f.pack();
             f.setLocation(300, 300);
-            f.show();
+            f.setVisible(true);
         } catch (Exception exc) {
             System.err.println("Error:");
             exc.printStackTrace();

--- a/src/ucar/unidata/ui/symbol/StationModelManager.java
+++ b/src/ucar/unidata/ui/symbol/StationModelManager.java
@@ -208,7 +208,7 @@ public class StationModelManager extends ResourceManager {
         if (initModel != null) {
             smc.setStationModel(initModel);
         }
-        frame.show();
+        frame.setVisible(true);
     }
 
     /**

--- a/src/ucar/unidata/util/GuiUtils.java
+++ b/src/ucar/unidata/util/GuiUtils.java
@@ -6807,7 +6807,7 @@ public class GuiUtils extends LayoutUtil {
             this.getContentPane().add(contents);
             this.pack();
             this.setLocation(200, 200);
-            this.show();
+            this.setVisible(true);
         }
 
         /**

--- a/src/ucar/unidata/util/JobManager.java
+++ b/src/ucar/unidata/util/JobManager.java
@@ -180,7 +180,7 @@ public class JobManager {
          * _more_
          */
         public void showDialog() {
-            getDialog().show();
+            getDialog().setVisible(true);
         }
 
         public JDialog getDialog() {

--- a/src/ucar/unidata/util/LogUtil.java
+++ b/src/ucar/unidata/util/LogUtil.java
@@ -678,7 +678,7 @@ public class LogUtil {
                                           Misc.newList(clearBtn, writeBtn))));
             consoleWindow = GuiUtils.makeWindow("Console", contents, 10, 10);
         }
-        consoleWindow.show();
+        consoleWindow.setVisible(true);
     }
 
 
@@ -985,7 +985,7 @@ public class LogUtil {
                                         - dialogSize.width / 2), Math.max(0,
                                             screenSize.height / 2
                                             - dialogSize.height / 2));
-            dialog.show();
+            dialog.setVisible(true);
             //            javax.swing.JOptionPane.showMessageDialog(
             //                null, contents, "Error", JOptionPane.ERROR_MESSAGE);
         }

--- a/src/ucar/unidata/util/MemoryMonitor.java
+++ b/src/ucar/unidata/util/MemoryMonitor.java
@@ -430,7 +430,7 @@ public class MemoryMonitor extends JPanel implements Runnable, Removable {
         MemoryMonitor mm = new MemoryMonitor();
         f.getContentPane().add(mm);
         f.pack();
-        f.show();
+        f.setVisible(true);
     }
 
 

--- a/src/ucar/unidata/view/sounding/NetcdfFileBrowser.java
+++ b/src/ucar/unidata/view/sounding/NetcdfFileBrowser.java
@@ -134,7 +134,7 @@ public class NetcdfFileBrowser extends SoundingFileBrowser {
 
         frame.getContentPane().add(ncfb.getContents());
         frame.pack();
-        frame.show();
+        frame.setVisible(true);
     }
 }
 

--- a/src/ucar/unidata/view/sounding/SoundingFileBrowser.java
+++ b/src/ucar/unidata/view/sounding/SoundingFileBrowser.java
@@ -293,6 +293,6 @@ public class SoundingFileBrowser {
 
         frame.getContentPane().add(ncfb.getContents());
         frame.pack();
-        frame.show();
+        frame.setVisible(true);
     }
 }

--- a/src/ucar/unidata/view/station/StationLocationRenderer.java
+++ b/src/ucar/unidata/view/station/StationLocationRenderer.java
@@ -668,7 +668,7 @@ public class StationLocationRenderer implements ucar.unidata.view.Renderer {
             info.setText("Station: " + s.name + "\n");
             info.append("  pos: " + posLatLon + "\n");
 
-            super.show();
+            super.setVisible(true);
         }
     }
 

--- a/src/ucar/visad/display/AnimationPropertiesDialog.java
+++ b/src/ucar/visad/display/AnimationPropertiesDialog.java
@@ -808,7 +808,7 @@ public class AnimationPropertiesDialog extends JDialog implements ActionListener
         predefinedDialog.getContentPane().add(contents);
         predefinedDialog.setLocation(predefinedBtn.getLocationOnScreen());
         predefinedDialog.pack();
-        predefinedDialog.show();
+        predefinedDialog.setVisible(true);
         return ok[0];
     }
 
@@ -907,11 +907,17 @@ public class AnimationPropertiesDialog extends JDialog implements ActionListener
     }
 
     /**
-     * Show the properties dialog
+     * Show or hide the properties dialog. Also, if {@code visible} is
+     * {@code true}, {@link #updateTimeline()} is called.
+     *
+     * @param visible if {@code true}, call {@link #updateTimeline()} and makes
+     * the properties dialog visible. Otherwise hides the properties dialog.
      */
-    public void show() {
-        updateTimeline();
-        super.show();
+    @Override public void setVisible(boolean visible) {
+        if (visible) {
+            updateTimeline();
+        }
+        super.setVisible(visible);
     }
 
 

--- a/src/ucar/visad/display/AnimationWidget.java
+++ b/src/ucar/visad/display/AnimationWidget.java
@@ -568,7 +568,7 @@ public class AnimationWidget extends SharableImpl implements ActionListener {
             propertiesDialog.setInfo(animationInfo);
         }
         propertiesDialog.boxPanel.applyProperties(boxPanel);
-        propertiesDialog.show();
+        propertiesDialog.setVisible(true);
     }
 
 


### PR DESCRIPTION
Most of these changes are pretty straightforward; I simply replaced calls to the deprecated `show` methods with `setVisible(true)`.

However, for the following classes, I removed the overridden (and deprecated) `show` methods, added `setVisible` methods, and adjusted code that called the old show methods:

`ucar.unidata.idv.ui.BundleTree`

`ucar.visad.display.AnimationPropertiesDialog`

The change to AnimationPropertiesDialog will only call `updateTimeline` if the dialog is to be made visible. This seemed to be in line with how `updateTimeline` is used…but I figured it was worth mentioning.

The only remaining call to a deprecated `show` method should be the one within `ucar.unidata.ui.IndependentWindow` at line 95. I left it because IndependentWindow is only ever used as an import in IdvWindow…maybe it can be removed? FWIW it seems to be an older version of `ucar.nc2.ui.widget.IndependentWindow`.
