### PR TITLE
Restore user's selected logo position.

### DIFF
--- a/src/ucar/unidata/idv/ViewManager.java
+++ b/src/ucar/unidata/idv/ViewManager.java
@@ -809,6 +809,13 @@ public class ViewManager extends SharableImpl implements ActionListener,
     protected Rectangle windowBounds;
 
     /**
+     * Logo position selection. The initial value is taken from the first item in
+     * {@link #logoPoses}. Note: the value should be something that
+     * {@link #findLoc(String)} understands.
+     */
+    private String selectedLogoPosition = logoPoses[0].getId().toString();
+
+    /**
      *  A parameter-less ctor for the XmlEncoder based decoding.
      */
     public ViewManager() {}
@@ -1470,7 +1477,7 @@ public class ViewManager extends SharableImpl implements ActionListener,
 
         logoPositionBox = new JComboBox(logoPoses);
         logoPositionBox.setToolTipText("Set the logo position on the screen");
-        logoPositionBox.setSelectedItem(findLoc(logos[0]));
+        logoPositionBox.setSelectedItem(findLoc(selectedLogoPosition));
         logoOffsetTextField = new JTextField(logos[1]);
         logoOffsetTextField.setToolTipText(
             "Set an offset from the position (x,y)");
@@ -2019,6 +2026,7 @@ public class ViewManager extends SharableImpl implements ActionListener,
             String logoPos =
                 ((TwoFacedObject) logoPositionBox.getSelectedItem()).getId()
                     .toString();
+            selectedLogoPosition = logoPos;
             String logoOff = logoOffsetTextField.getText().trim();
 
             setLogoPosition(makeLogoPosition(logoPos, logoOff));


### PR DESCRIPTION
If a user does something like:
1. Open the `View>Properties` window.
2. Select a screen position other than `Lower Left`.
3. Click `OK` to close the window.
4. Reopen the `View>Properties` window.

Prior to this commit, the screen position will be reset to "Lower Left". This commit simply remembers the user's selection by storing it in a new ViewManager String field ("selectedLogoPosition").

Since the selection is just an instance field, the selected value is only remembered for the lifetime of the ViewManager and each ViewManager can have a different selected value (but this seems to conform pretty well with how things “should” work?).

This is a fix for Inquiry 1219:
http://mcidas.ssec.wisc.edu/inquiry-v/?inquiry=1219
