### PR TITLE
Logo position selection retry.

### DIFF
--- a/src/ucar/unidata/idv/ViewManager.java
+++ b/src/ucar/unidata/idv/ViewManager.java
@@ -1547,10 +1547,10 @@ public class ViewManager extends SharableImpl implements ActionListener,
             logoP = "ll";
             logoO = "0,0";
         } else {
-            int firstComma = position.indexOf(",");
+            int firstComma = position.indexOf(',');
 
             if (firstComma > 0) {
-                logoP = position.substring(0, firstComma - 1);
+                logoP = position.substring(0, firstComma);
                 logoO = position.substring(firstComma + 1);
             } else {
                 logoP = position;


### PR DESCRIPTION
Many thanks to @donmurray for pointing out the problem with bundles in #75 (as well as for the hint)! 

The bug turns out to be in “parseLogoPosition”. Given input like `mm,100,-100`, parseLogoPosition would return a string array containing `m` and `100,-100` (expected output would be `mm` and `100,-100`).

To recap…if a user does something like:
1. Open the `View>Properties` window.
2. Select a screen position other than `Lower Left`.
3. Click `OK` to close the window.
4. Reopen the `View>Properties` window.

Prior to this commit, the screen position will be reset to `Lower Left`.

This is a fix for Inquiry 1219:

http://mcidas.ssec.wisc.edu/inquiry-v/?inquiry=1219
