### PR TITLE
Fix typo in Layout Model Properties dialog.

### DIFF
--- a/src/ucar/unidata/ui/symbol/PropertiesDialog.java
+++ b/src/ucar/unidata/ui/symbol/PropertiesDialog.java
@@ -847,16 +847,18 @@ public class PropertiesDialog implements ActionListener {
 
 
     /**
-     * Se tthe title on the dialog window
+     * Set the title on the dialog window.
      */
     private void setDialogTitle() {
-	if(!doMultiple()) {
-	    dialog.setTitle(GuiUtils.getApplicationTitle() +"Layout Model Editor - Properties Dialog - "
-			    + symbol.getLabel());
-	} else {
-	    dialog.setTitle(GuiUtils.getApplicationTitle() +"Layout Model Editor - Properties Dialog - Serlected");
-
-	}
+        StringBuilder title =
+            new StringBuilder(GuiUtils.getApplicationTitle())
+                .append("Layout Model Editor - Properties Dialog - ");
+        if (!doMultiple()) {
+            title.append(symbol.getLabel());
+        } else {
+            title.append("Selected");
+        }
+        dialog.setTitle(title.toString());
     }
 
     /**


### PR DESCRIPTION
Here’s how to replicate the typo:
1. In a display window, click Tools>Layout Model Editor.
2. Click and drag to select the components of the current layout model.
3. Go to Edit>Set properties on selected.

The dialog title should contain "Serlected" (rather than "Selected").
