### PR TITLE
Fix buffer bug, reads greater than 2 GB were failing [1483]

### DIFF
--- a/src/ucar/unidata/data/CacheDataSource.java
+++ b/src/ucar/unidata/data/CacheDataSource.java
@@ -22,45 +22,40 @@
 
 package ucar.unidata.data;
 
-
-import org.w3c.dom.*;
-
-import ucar.unidata.util.FileManager;
-import ucar.unidata.util.GuiUtils;
-import ucar.unidata.util.IOUtil;
-
-
-import ucar.unidata.util.LogUtil;
-import ucar.unidata.util.Misc;
-import ucar.unidata.util.PatternFileFilter;
-import ucar.unidata.util.StringUtil;
-
-import ucar.unidata.xml.XmlUtil;
-
-import visad.Data;
-import visad.DataReference;
-
-import visad.VisADException;
-
-import java.awt.event.*;
-
-import java.io.*;
-
+import java.awt.event.ActionEvent;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.Serializable;
-
 import java.rmi.RemoteException;
-
-
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
-import java.util.zip.*;
+import javax.swing.AbstractAction;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JProgressBar;
 
-import javax.swing.*;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
+import ucar.unidata.util.FileManager;
+import ucar.unidata.util.GuiUtils;
+import ucar.unidata.util.IOUtil;
+import ucar.unidata.util.LogUtil;
+import ucar.unidata.util.Misc;
+import ucar.unidata.util.PatternFileFilter;
+import ucar.unidata.util.StringUtil;
+import ucar.unidata.xml.XmlUtil;
+
+import visad.Data;
+import visad.VisADException;
 
 /**
  * Used to cache  a data choice and its data
@@ -222,7 +217,7 @@ public class CacheDataSource extends DataSourceImpl {
             Element root  = doc.getDocumentElement();
 
 
-            int     total = 0;
+            long     total = 0;
             ZipOutputStream zos =
                 new ZipOutputStream(new FileOutputStream(filename));
             for (int i = 0; i < holders.size(); i++) {

--- a/src/ucar/unidata/util/IOUtil.java
+++ b/src/ucar/unidata/util/IOUtil.java
@@ -20,25 +20,34 @@
 
 package ucar.unidata.util;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
 
-import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
 
-import java.math.*;
-
-import java.net.*;
-
-import java.security.*;
+import java.security.MessageDigest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
-
-import java.util.zip.*;
-
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
 
 /**
  * A set of io related utilities
@@ -552,7 +561,7 @@ public class IOUtil {
      * @return How may bytes were written
      * @throws IOException On badness
      */
-    public static int writeTo(InputStream from, OutputStream to)
+    public static long writeTo(InputStream from, OutputStream to)
             throws IOException {
         return writeTo(from, to, null, 0);
     }
@@ -598,15 +607,15 @@ public class IOUtil {
      *
      * @throws IOException  problem writing to file.
      */
-    public static int writeTo(URL from, File file, Object loadId)
+    public static long writeTo(URL from, File file, Object loadId)
             throws IOException {
         URLConnection    connection = from.openConnection();
         InputStream      is         = connection.getInputStream();
         int              length     = connection.getContentLength();
-        int              numBytes   = -1;
+        long             numBytes   = -1;
         FileOutputStream fos        = new FileOutputStream(file);
         try {
-            int result = writeTo(is, fos, loadId, length);
+            long result = writeTo(is, fos, loadId, length);
             numBytes = result;
         } finally {
             close(fos);
@@ -636,12 +645,12 @@ public class IOUtil {
      *
      * @throws IOException On badness
      */
-    public static int writeTo(InputStream from, OutputStream to,
-                              Object loadId, int length)
+    public static long writeTo(InputStream from, OutputStream to,
+                              Object loadId, long length)
             throws IOException {
         from = new BufferedInputStream(from, 100000);
         byte[] content = new byte[100000];
-        int    total   = 0;
+        long    total   = 0;
         while (true) {
             int howMany = from.read(content);
             if (howMany <= 0) {
@@ -804,7 +813,7 @@ public class IOUtil {
 
             files.add(path);
             OutputStream to    = new FileOutputStream(path);
-            int          bytes = writeTo(from, to, loadId, length);
+            long          bytes = writeTo(from, to, loadId, length);
             try {
                 from.close();
             } catch (Exception exc) {}


### PR DESCRIPTION
Hi guys - very important this one gets in.  Definite buffer overflow issue in IOUtil.writeTo() 
The counter was an int and of course that means our read/write limit is 2 GB.  I had to track
it down because MUG reported Suomi M-BAND bundles worked fine, but I-BAND bundles
would fail to save and reload.  The only obvious difference to me was size (I-BAND granules
are MUCH bigger).  

Watch the writeTo logging I added overflow Java signed int limits:

11:56:39.193 [AWT-EventQueue-0] TRACE e.w.ssec.mcidasv.PersistenceManager - writeTo: Transferred 2147300 Kbytes
11:56:39.194 [AWT-EventQueue-0] TRACE e.w.ssec.mcidasv.PersistenceManager - writeTo: num read: 100000
11:56:39.194 [AWT-EventQueue-0] TRACE e.w.ssec.mcidasv.PersistenceManager - writeTo: Transferred 2147400 Kbytes
11:56:39.195 [AWT-EventQueue-0] TRACE e.w.ssec.mcidasv.PersistenceManager - writeTo: num read: 100000
11:56:39.195 [AWT-EventQueue-0] TRACE e.w.ssec.mcidasv.PersistenceManager - writeTo: Transferred -2147467 Kbytes
11:56:39.196 [AWT-EventQueue-0] TRACE e.w.ssec.mcidasv.PersistenceManager - writeTo: num read: 100000
11:56:39.196 [AWT-EventQueue-0] TRACE e.w.ssec.mcidasv.PersistenceManager - writeTo: Transferred -2147367 Kbytes

The negative total returned by the method is considered a failure by callers.  
Long story short (twisted pun, sorry), cumulative count needed to be a long.
Luckily the ripple to other code was not bad.

```
public static long writeTo(InputStream from, OutputStream to,
                          Object loadId, long length)
        throws IOException {
    from = new BufferedInputStream(from, 100000);
    byte[] content = new byte[100000];
    long    total   = 0;
    while (true) {
        int howMany = from.read(content);
        if (howMany <= 0) {
            break;
        }
        total += howMany;
        if ( !JobManager.getManager().canContinue(loadId)) {
            return -1;
        }
        String msg;
        if (length > 0) {
            msg = "Transferred " + (total / 1000) + "/" + (length / 1000)
                  + " Kbytes ";
        } else {
            msg = "Transferred " + ((total) / 1000) + " Kbytes";
        }

        JobManager.getManager().setDialogLabel2(loadId, msg);

        to.write(content, 0, howMany);
    }
    return total;
}
```
