### PR TITLE
Avoid NPEs due to unpersistence order uncertainty [1483]

### DIFF
--- a/src/ucar/unidata/idv/ViewManager.java
+++ b/src/ucar/unidata/idv/ViewManager.java
@@ -2924,9 +2924,14 @@ public class ViewManager extends SharableImpl implements ActionListener,
      */
     protected BooleanProperty getBooleanProperty(String propertyId,
             boolean dflt) {
-        if (booleanPropertyMap.size() == 0) {
-            initBooleanProperties();
-        }
+    	
+    	// avoid unpersistence order inconsistency bug, we have seen NPEs 
+    	// here because the Map is sometimes instantiated before the IDV ref!
+    	if (getIdv() != null) {
+    		if (booleanPropertyMap.size() == 0) {
+    			initBooleanProperties();
+    		}
+    	}
 
         BooleanProperty bp =
             (BooleanProperty) booleanPropertyMap.get(propertyId);


### PR DESCRIPTION
I can provide more detail if needed - you guys have probably seen similar things. The root of the problem is order of persisted objects in bundles can vary, and this sometimes causes problems during unpersistence if assumptions are made about order of instantiation. 
