### PR TITLE
Revert "Avoid NPEs due to unpersistence order uncertainty [1483]"

### DIFF
--- a/src/ucar/unidata/idv/ViewManager.java
+++ b/src/ucar/unidata/idv/ViewManager.java
@@ -2924,14 +2924,9 @@ public class ViewManager extends SharableImpl implements ActionListener,
      */
     protected BooleanProperty getBooleanProperty(String propertyId,
             boolean dflt) {
-    	
-    	// avoid unpersistence order inconsistency bug, we have seen NPEs 
-    	// here because the Map is sometimes instantiated before the IDV ref!
-    	if (getIdv() != null) {
-    		if (booleanPropertyMap.size() == 0) {
-    			initBooleanProperties();
-    		}
-    	}
+        if (booleanPropertyMap.size() == 0) {
+            initBooleanProperties();
+        }
 
         BooleanProperty bp =
             (BooleanProperty) booleanPropertyMap.get(propertyId);


### PR DESCRIPTION
Reverts Unidata/IDV#80
