### PR TITLE
Avoid IndexOutOfBoundsException if dataSources is 0 length

### DIFF
--- a/src/ucar/unidata/idv/control/ImagePlanViewControl.java
+++ b/src/ucar/unidata/idv/control/ImagePlanViewControl.java
@@ -177,7 +177,7 @@ public class ImagePlanViewControl extends PlanViewControl {
         List dataSources = new ArrayList();
 
         dc.getDataSources(dataSources);
-        if(!(dataSources.get(0) instanceof AddeImageDataSource))
+        if((dataSources.size() == 0) || !(dataSources.get(0) instanceof AddeImageDataSource))
             return null;
 
         AddeImageDataSource aids = (AddeImageDataSource) dataSources.get(0);


### PR DESCRIPTION
Hi guys,

I was hitting an `IndexOutOfBoundsException` due to trying to index a 0-length `ArrayList` while working on our Jython scripting stuff.  I figure it's OK to just return null if `dataSources` is 0-length since that's what happens anyway, if `dataSources.get(0)` isn't an `AddeImageDataSource`.

Thanks!
Mike
