### PR TITLE
Fix problem with leaving full screen mode.

### DIFF
--- a/src/ucar/unidata/idv/ViewManager.java
+++ b/src/ucar/unidata/idv/ViewManager.java
@@ -183,6 +183,7 @@ import javax.swing.JTabbedPane;
 import javax.swing.JTextField;
 import javax.swing.JToggleButton;
 import javax.swing.ScrollPaneConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.border.Border;
 import javax.swing.border.MatteBorder;
 import javax.swing.event.ChangeEvent;
@@ -6989,7 +6990,7 @@ public class ViewManager extends SharableImpl implements ActionListener,
         };
 
         // GuiUtils.invokeInSwingThread(runnable);
-        Misc.run(runnable);
+        SwingUtilities.invokeLater(runnable);
     }
 
     /**


### PR DESCRIPTION
All this commit does is explicitly run the logic of `resetFullScreen` on the EDT via `invokeLater`.

I did test things with `GuiUtils.invokeInSwingThread` and it seemed to work, but I opted for `invokeLater` because:
1. `GuiUtils.invokeInSwingThread` seems semantically equivalent to always using `SwingUtilities.invokeAndWait` ([and that shouldn’t be called from the EDT](http://docs.oracle.com/javase/7/docs/api/javax/swing/SwingUtilities.html#invokeAndWait%28java.lang.Runnable%29)).
2. Adding the runnable to the end of the EDTs queue—rather than executing the runnable immediately—seems like the safer choice, as there could be situations where events/threads reference the `fullScreenWindow` JFrame that has already been disposed of and nulled out.
