### PR TITLE
Improve projection manager label.

### DIFF
--- a/src/ucar/unidata/view/geoloc/ProjectionManager.java
+++ b/src/ucar/unidata/view/geoloc/ProjectionManager.java
@@ -739,7 +739,7 @@ public class ProjectionManager implements ActionListener {
         }
 
         if (current != null) {
-            mapLabel.setText(current.toString());
+            mapLabel.setText(current.getName());
         }
         npViewControl.setProjectionImpl(current);
     }

--- a/src/ucar/unidata/view/geoloc/ProjectionManager.java
+++ b/src/ucar/unidata/view/geoloc/ProjectionManager.java
@@ -349,7 +349,7 @@ public class ProjectionManager implements ActionListener {
         if (null != (current = projTable.getSelected())) {
             setWorkingProjection(current);
             projTable.setCurrentProjection(current);
-            mapLabel.setText(current.toString());
+            mapLabel.setText(current.getName());
         }
 
         /* listen for new working Projections from projTable */


### PR DESCRIPTION
LambertConformal's toString() method returns something along the lines of `LambertConformal{earth_radius=6371.229, lat0=25.0, lon0=-95.0, par1=25.0, par2=25.0, falseEasting=0.0, falseNorthing=0.0}`.

I'm guessing the label above the map from `Tools>Projections Manager` should use getName() (which looks like `US>CONUS`)…but if not, no worries!
