### PR TITLE
Set idv.capture.gif.useGlobalTable default to true

### DIFF
--- a/src/ucar/unidata/idv/resources/idv.properties
+++ b/src/ucar/unidata/idv/resources/idv.properties
@@ -481,9 +481,6 @@ idv.usetimedriver=true
 ##Can set the frame cycle time (ms)
 ##idv.minimumframecycletime=10
 
-## Flag to use global color table for creating animated gifs
-idv.capture.gif.useGlobalTable=true
-
 idv.install.buildproperties=http://www.unidata.ucar.edu/software/idv/release/build.properties
 idv.install.nightlyjars=ftp://ftp.unidata.ucar.edu/pub/idv/nightly/idv_jars_2.9a1.zip
 idv.install.currentjars=ftp://ftp.unidata.ucar.edu/pub/idv/nightly/idv_jars_2.9a1.zip

--- a/src/ucar/unidata/idv/ui/ImageSequenceGrabber.java
+++ b/src/ucar/unidata/idv/ui/ImageSequenceGrabber.java
@@ -2202,7 +2202,7 @@ public class ImageSequenceGrabber implements Runnable, ActionListener {
                     double  rate   = 1.0 / displayRate;
                     boolean useGCT = idv.getStateManager().getProperty(
                                          "idv.capture.gif.useGlobalTable",
-                                         false);
+                                         true);
 
                     AnimatedGifEncoder.createGif(movieFile,
                             ImageWrapper.makeFileList(images),


### PR DESCRIPTION
Having it default to `false` can result in output that looks like (watch the color table in particular):

http://mcidas.ssec.wisc.edu/tmp/example_per_frame.gif

Having the property default to `true`:

http://mcidas.ssec.wisc.edu/tmp/example_all_frames.gif

