### PR TITLE
Add property that disables IDV version check.

### DIFF
--- a/src/ucar/unidata/idv/IntegratedDataViewer.java
+++ b/src/ucar/unidata/idv/IntegratedDataViewer.java
@@ -627,7 +627,9 @@ public class IntegratedDataViewer extends IdvBase implements ControlContext,
         getIdvUIManager().initDone();
         getArgsManager().initDone();
 
-        if (!getStateManager().getRunningIsl()) {
+        boolean doVersionCheck =
+            getStateManager().getProperty("idv.doversioncheck", true);
+        if (!getStateManager().getRunningIsl() && doVersionCheck) {
             try {
                 OldVersionCheck.check(this);
             } catch (Exception e) {


### PR DESCRIPTION
This adds a property, `idv.doversioncheck`, to allow/disallow IDV version checking. Default behavior is to always perform the check.

This approach allows subclasses of `IntegratedDataViewer` to simply override `initInner()` and set `idv.doversioncheck` to `false` before calling the IDV's `initInner()`.
