### PR TITLE
Allow user to control use of global GIF palette.

### DIFF
--- a/src/ucar/unidata/idv/ui/ImageSequenceGrabber.java
+++ b/src/ucar/unidata/idv/ui/ImageSequenceGrabber.java
@@ -205,7 +205,7 @@ public class ImageSequenceGrabber implements Runnable, ActionListener {
 
     /** Tooltip text for global palette checkbox. */
     public static final String GLOBAL_PALETTE_TOOLTIP =
-        "<html>Turn off to correct colors for low-light animations.<br/>" +
+        "<html>Turn off to correct colors for varying color animations.<br/>" +
         "<br/></br/>This option controls whether or not a resulting GIF " +
         "image will use a color palette<br/>taken from all the frames of the" +
         " animation.<br/><br/>If the option is turned off, the animation's " +
@@ -1473,7 +1473,7 @@ public class ImageSequenceGrabber implements Runnable, ActionListener {
                 "Also save the viewpoint matrices as an 'xidv' file");
 
             JCheckBox otherGlobalPaletteBox =
-                new JCheckBox("Use 'global' GIF color palette",
+                new JCheckBox("Use constant color palette for GIF",
                     getGlobalPaletteValue());
             otherGlobalPaletteBox.setToolTipText(GLOBAL_PALETTE_TOOLTIP);
             otherGlobalPaletteBox.addActionListener(e -> {


### PR DESCRIPTION
This adds a checkbox to the "Save" dialog created by the "Movie Capture" window. The state of the checkbox represents the value of `idv.capture.gif.useGlobalTable`.

The default value of `idv.capture.gif.useGlobalTable` is `true`.

You may want to change the tooltip text; we decided to err on the "descriptive" side of things. Java has apparently decided that tooltips should be "dismissed" after 4 seconds, and this totally-not-user-hostile feature can make reading said tooltip somewhat challenging. The dismissal _feature_ can be effectively disabled by doing something like the following:

```java
import javax.swing.ToolTipManager;
...
ToolTipManager.sharedInstance().setDismissDelay(Integer.MAX_VALUE);
...
```
Example with `idv.capture.gif.useGlobalTable` set to `false`:
![Not using global GIF palette](http://mcidas.ssec.wisc.edu/tmp/example_per_frame.gif)

Example with `idv.capture.gif.useGlobalTable` set to `true`:
![Using global GIF palette](http://mcidas.ssec.wisc.edu/tmp/example_all_frames.gif)

This is a refinement of #100.