### PR TITLE
Don't truncate "Write Local Grid" dialog labels

### DIFF
--- a/src/ucar/unidata/data/grid/GeoGridDataSource.java
+++ b/src/ucar/unidata/data/grid/GeoGridDataSource.java
@@ -785,9 +785,11 @@ public class GeoGridDataSource extends GridDataSource {
                 continue;
             }
             String label = dataChoice.getDescription();
-            if (label.length() > 30) {
-                label = label.substring(0, 29) + "...";
-            }
+            /* Fix for McV inq. 1887: Don't truncate labels in "Write Local 
+               Grid" dialog.  */
+            // if (label.length() > 30) {
+            //     label = label.substring(0, 29) + "...";
+            // }
             JCheckBox cbx =
                 new JCheckBox(label,
                               currentDataChoices.get(dataChoice.getName())


### PR DESCRIPTION
Hi guys,
Currently, "Write Local Grid" dialog box truncates data choice labels to 30 characters, which is too short for many gridded fields. The dialog box looks fine without any truncation, so this commit just disables the truncation.
Before fix:
<img width="388" alt="screen shot 2015-10-07 at 2 23 57 pm" src="https://cloud.githubusercontent.com/assets/1490630/10348655/0dd10be4-6d00-11e5-91c1-ca440ce260ff.png">
<img width="567" alt="screen shot 2015-10-07 at 2 26 59 pm" src="https://cloud.githubusercontent.com/assets/1490630/10348664/12827718-6d00-11e5-878f-0996437b943d.png">
After fix:
<img width="593" alt="screen shot 2015-10-07 at 2 24 12 pm" src="https://cloud.githubusercontent.com/assets/1490630/10348668/19c4c512-6d00-11e5-9476-75fd00e03816.png">


This fixes [McV inquiry 1887](http://mcidas.ssec.wisc.edu/inquiry-v/index.php?inquiry=1887).