### PR TITLE
Add exportZidv jython function.

### DIFF
--- a/src/ucar/unidata/idv/resources/python/isl.py
+++ b/src/ucar/unidata/idv/resources/python/isl.py
@@ -12,7 +12,20 @@ sys.add_package('visad.python');
 sys.add_package('java.util');
 
 from visad.python.JPythonMethods import *
+
 from java.util import ArrayList
+from java.util import Hashtable
+
+def exportZidv(filename, display, displayAreaSubset=True):
+    control = islInterpreter.findDisplayControl(display)
+    if control:
+        if displayAreaSubset:
+            props = Hashtable()
+            props.put('DisplayAreaSubset', displayAreaSubset)
+            control.applyProperties(props)
+        what = islInterpreter.applyMacros('zidv')
+        filename = islInterpreter.applyMacros(filename)
+        idv.getPersistenceManager().doSaveAs(filename)
 
 def pause():
     idv.waitUntilDisplaysAreDone();


### PR DESCRIPTION
Hi Yuan,

I'll likely clean this up a little more, but I imagine the functionality will stay essentially the same.

Jon

Example usage:

``` python
# bring in a bundle
loadBundle('/tmp/test.xidv')

# export using DisplayAreaSubset
exportZidv('/tmp/test.zidv', 'class:ucar.unidata.idv.control.ContourPlanViewControl')

# export without using DisplayAreaSubset
exportZidv('/tmp/test.zidv', 'class:ucar.unidata.idv.control.ContourPlanViewControl', False)
```
