### PR TITLE
Prevent throwing NPE at user if display type is a favorite [2185]

### DIFF
--- a/src/ucar/unidata/idv/ControlDescriptor.java
+++ b/src/ucar/unidata/idv/ControlDescriptor.java
@@ -553,7 +553,14 @@ public class ControlDescriptor {
     public void showHelp() {
         try {
             if (prototype == null) {
-                prototype = (DisplayControl) controlClass.newInstance();
+                // TJJ Sep 2016
+                // If user saved a favorite, the display type will be a template prototype object
+                // and controlClass will be null. This fix prevents NPE on F1 (View Help)
+                if (controlClass == null) {
+                    prototype = displayTemplatePrototype;
+                } else {
+                    prototype = (DisplayControl) controlClass.newInstance();
+                }
                 prototype.initBasic(controlId, dataCategories, properties);
             }
             prototype.showHelp();


### PR DESCRIPTION
Hi guys - simple change here.  Bob noticed if you save a display type as a favorite, then do a View Help, you get an NPE.  Details are in the McV Inquiry:

http://mcidas.ssec.wisc.edu/inquiry-v/?inquiry=2185