### PR TITLE
Fix JTable row selection problem.

### DIFF
--- a/src/ucar/unidata/idv/ui/AliasEditor.java
+++ b/src/ucar/unidata/idv/ui/AliasEditor.java
@@ -342,7 +342,8 @@ public class AliasEditor extends IdvManager {
      */
     private void handleMouseEvent(MouseEvent e, JTable table,
                                   final int resourceIdx) {
-        final int row = table.rowAtPoint(e.getPoint());
+        final int origRow   = table.rowAtPoint(e.getPoint());
+        final int row       = table.convertRowIndexToModel(origRow);
         if ( !SwingUtilities.isRightMouseButton(e)) {
             if (e.getClickCount() > 1) {
                 if (isEditableResource(resourceIdx)) {
@@ -353,7 +354,7 @@ public class AliasEditor extends IdvManager {
             }
             return;
         }
-        table.getSelectionModel().setSelectionInterval(row, row);
+        table.getSelectionModel().setSelectionInterval(origRow, origRow);
         JPopupMenu popup = new JPopupMenu();
         JMenuItem  mi    = null;
         if (isEditableResource(resourceIdx)) {

--- a/src/ucar/unidata/idv/ui/ParamDefaultsEditor.java
+++ b/src/ucar/unidata/idv/ui/ParamDefaultsEditor.java
@@ -650,7 +650,8 @@ public class ParamDefaultsEditor extends IdvManager implements ActionListener {
 
 
                 public void mouseReleased(MouseEvent e) {
-                    final int row       = rowAtPoint(e.getPoint());
+                    final int origRow   = rowAtPoint(e.getPoint());
+                    final int row       = convertRowIndexToModel(origRow);
                     ParamInfo paramInfo = getInfo(row);
                     if ( !SwingUtilities.isRightMouseButton(e)) {
                         if ((e.getClickCount() > 1) && (paramInfo != null)) {
@@ -663,7 +664,7 @@ public class ParamDefaultsEditor extends IdvManager implements ActionListener {
                         return;
                     }
 
-                    getSelectionModel().setSelectionInterval(row, row);
+                    getSelectionModel().setSelectionInterval(origRow, origRow);
                     JPopupMenu popup = new JPopupMenu();
                     makePopupMenu(popup, row);
                     popup.show((Component) e.getSource(), e.getX(), e.getY());

--- a/src/ucar/unidata/idv/ui/ParamGroupsEditor.java
+++ b/src/ucar/unidata/idv/ui/ParamGroupsEditor.java
@@ -460,7 +460,8 @@ public class ParamGroupsEditor extends IdvManager implements ActionListener {
 
 
                 public void mouseReleased(MouseEvent e) {
-                    final int row       = rowAtPoint(e.getPoint());
+                    final int origRow   = rowAtPoint(e.getPoint());
+                    final int row       = convertRowIndexToModel(origRow);
                     DataGroup dataGroup = getDataGroup(row);
                     if ( !SwingUtilities.isRightMouseButton(e)) {
                         if ((e.getClickCount() > 1) && (dataGroup != null)) {
@@ -473,7 +474,7 @@ public class ParamGroupsEditor extends IdvManager implements ActionListener {
                         return;
                     }
 
-                    getSelectionModel().setSelectionInterval(row, row);
+                    getSelectionModel().setSelectionInterval(origRow, origRow);
                     JPopupMenu popup = new JPopupMenu();
                     makePopupMenu(popup, row);
                     popup.show((Component) e.getSource(), e.getX(), e.getY());
@@ -930,7 +931,7 @@ public class ParamGroupsEditor extends IdvManager implements ActionListener {
 
 
     /**
-     * Create xml dom from the given list of {@link ucar.unidata.idv.ui.DataGroup}-s
+     * Create xml dom from the given list of {@link DataGroup DataGroups}
      *
      * @param doc The document to write to
      * @param paramGroups List of param infos


### PR DESCRIPTION
This is a follow-up to #114...

It turns out that the underlying table model won't be updated when a JTable's column has been sorted. Luckily, there's the handy `convertRowIndexToModel` method for these sorts of things.

Here's how to reproduce the problem, courtesy of Bob:

1. Open the Parameter Defaults Editor.
2. Go to the System Defaults tab.
3. Scroll down until you find the 'temp' Parameter, right-click on 'temp' and choose 'Copy Row to User's Defaults' (or double-click on 'temp'... does the same thing).

At this point, you should see the bug. In McV, selecting 'temp' results in 'z_frzlvl' being brought over.