### PR TITLE
Two modifications to showOkCancelDialog.

### DIFF
--- a/src/ucar/unidata/util/GuiUtils.java
+++ b/src/ucar/unidata/util/GuiUtils.java
@@ -2292,7 +2292,7 @@ public class GuiUtils extends LayoutUtil {
 
 
     /**
-     * Show a modeful  Ok/Cancel dialog.
+     * Show a modal Ok/Cancel dialog.
      *
      * @param f                The frame to attach to
      * @param title            The window title
@@ -2310,6 +2310,30 @@ public class GuiUtils extends LayoutUtil {
                                              Component src,
                                              List actionComponents,
                                              String okLabel) {
+        return showOkCancelDialog(f, title, contents, src, actionComponents, okLabel, true);
+    }
+    
+    /**
+     * Show a modal Ok/Cancel dialog.
+     *
+     * @param f                The frame to attach to
+     * @param title            The window title
+     * @param contents         The gui contents to show
+     * @param src              Where should the window popup
+     * @param actionComponents If non-null then these are components
+     *                         in the contents (e.g., JTextField) that an
+     *                         action listener is added to to do the Ok
+     *                         on an action event
+     * @param okLabel          text for the OK button
+     * @param resizable        Whether or not the dialog can be resized
+     * @return True if Ok was pressed, false otherwise
+     */
+    public static boolean showOkCancelDialog(Window f, String title,
+                                             Component contents,
+                                             Component src,
+                                             List actionComponents,
+                                             String okLabel,
+                                             boolean resizable) {
         if ( !LogUtil.getInteractiveMode()) {
             throw new IllegalStateException(
                 "Cannot show dialog in non-interactive mode");
@@ -2321,7 +2345,7 @@ public class GuiUtils extends LayoutUtil {
             ActionListener actionListener = new ActionListener() {
                 public void actionPerformed(ActionEvent event) {
                     listener.actionPerformed(new ActionEvent(this, 0,
-                            GuiUtils.CMD_OK));
+                        GuiUtils.CMD_OK));
                 }
             };
             for (int i = 0; i < actionComponents.size(); i++) {
@@ -2332,18 +2356,21 @@ public class GuiUtils extends LayoutUtil {
                     ((JComboBox) o).getEditor().addActionListener(
                         actionListener);
                 }
-
+                
             }
         }
+        
+        dialog.setPreferredSize(contents.getPreferredSize());
         packDialog(dialog, centerBottom(contents, buttons));
         setDefaultButton(buttons, dialog.getRootPane());
+        dialog.setResizable(resizable);
         if (src != null) {
             dialog.setLocation(getLocation(src));
             dialog.setVisible(true);
         } else {
             showInCenter(dialog);
         }
-
+        
         return listener.theObject.equals(GuiUtils.CMD_OK);
     }
 


### PR DESCRIPTION
Tommy and I thought this may be of use (but no biggie if it isn't!). I'll just include the text from the commit message below.

This adds a parameter named `resizable` to a new `showOkCancelDialog` method that controls whether or not the resulting dialog can be resized.

The other change is that the now the resulting dialog's preferred size is set to the preferred size of the `contents` parameter.

Existing calls in the IDV to `showOkCancelDialog` should behave the same as before, as the default behavior is to set `resizable` to `true`.