### PR TITLE
Fix for sizing bug in Pull Request #120

### DIFF
--- a/src/ucar/unidata/util/GuiUtils.java
+++ b/src/ucar/unidata/util/GuiUtils.java
@@ -2310,6 +2310,33 @@ public class GuiUtils extends LayoutUtil {
                                              Component src,
                                              List actionComponents,
                                              String okLabel) {
+        return showOkCancelDialog(f, title, contents, src, actionComponents, okLabel, true, null);
+    }
+    
+    /**
+     * Show a modal Ok/Cancel dialog.
+     *
+     * @param f                The frame to attach to
+     * @param title            The window title
+     * @param contents         The gui contents to show
+     * @param src              Where should the window popup
+     * @param actionComponents If non-null then these are components
+     *                         in the contents (e.g., JTextField) that an
+     *                         action listener is added to to do the Ok
+     *                         on an action event
+     * @param okLabel          text for the OK button
+     * @param resizable        Whether or not the dialog can be resized.
+     * @param dialogPrefSize   If not {@code null}, use as preferred size of
+     *                         resulting dialog.
+     * @return True if Ok was pressed, false otherwise
+     */
+    public static boolean showOkCancelDialog(Window f, String title,
+                                             Component contents,
+                                             Component src,
+                                             List actionComponents,
+                                             String okLabel,
+                                             boolean resizable,
+                                             Dimension dialogPrefSize) {
         if ( !LogUtil.getInteractiveMode()) {
             throw new IllegalStateException(
                 "Cannot show dialog in non-interactive mode");
@@ -2332,11 +2359,14 @@ public class GuiUtils extends LayoutUtil {
                     ((JComboBox) o).getEditor().addActionListener(
                         actionListener);
                 }
-
             }
+        }
+        if (dialogPrefSize != null) {
+            dialog.setPreferredSize(dialogPrefSize);
         }
         packDialog(dialog, centerBottom(contents, buttons));
         setDefaultButton(buttons, dialog.getRootPane());
+        dialog.setResizable(resizable);
         if (src != null) {
             dialog.setLocation(getLocation(src));
             dialog.setVisible(true);


### PR DESCRIPTION
Sorry about the previous iteration not working so well. 😓 

At any rate, I believe this commit should be working as expected. For the sake of completeness, here's the commit message:

The new `showOkCancelDialog` method now has a parameter named `dialogPrefSize`.

If the value is non-null, the dialog will use dialogPrefSize as its preferred size. If the value is null, we rely on the wisdom of `pack()` (which is the original behavior of showOkCancelDialog).