### PR TITLE
Allow specifying default server for ADDE choosers.

### DIFF
--- a/src/ucar/unidata/idv/chooser/adde/AddeChooser.java
+++ b/src/ucar/unidata/idv/chooser/adde/AddeChooser.java
@@ -35,6 +35,7 @@ import ucar.unidata.geoloc.projection.*;
 
 import ucar.unidata.gis.mcidasmap.McidasMap;
 
+import ucar.unidata.idv.IdvObjectStore;
 import ucar.unidata.idv.chooser.IdvChooser;
 import ucar.unidata.idv.chooser.IdvChooserManager;
 import ucar.unidata.idv.chooser.TimesChooser;
@@ -649,18 +650,39 @@ public class AddeChooser extends TimesChooser {
         }
     }
 
-
+    /**
+     * Return either the user's last selected server and group for a given
+     * ADDE chooser, or check {@code idv.properties} if no selection exists.
+     *
+     * @return Array of two strings. First value is the server, and the second
+     *         is the group. {@code null} signifies that there was no
+     *         {@literal "last"} selection as well as no default selection.
+     */
+    protected String[] getDefaultServerSelection() {
+        String id = getId();
+        String stateProp = PREF_SERVERSTATE + '.' + id;
+        IdvObjectStore store = getIdv().getStore();
+        String[] serverState = (String[])store.get(stateProp);
+        if (serverState == null) {
+            String serverProp = "idv.defaultselection." + id + ".server";
+            String groupProp = "idv.defaultselection." + id + ".group";
+            String server = (String)store.get(serverProp);
+            String group = (String)store.get(groupProp);
+            if ((server != null) && (group != null)) {
+                serverState = new String[] { server, group };
+            }
+        }
+        return serverState;
+    }
 
     /**
      * Load any saved server state
      */
-    private void loadServerState() {
+    protected void loadServerState() {
         if (addeServers == null) {
             return;
         }
-        String id = getId();
-        String[] serverState =
-            (String[]) getIdv().getStore().get(PREF_SERVERSTATE + "." + id);
+        String[] serverState = getDefaultServerSelection();
         if (serverState == null) {
             return;
         }

--- a/src/ucar/unidata/idv/chooser/adde/AddePointDataChooser.java
+++ b/src/ucar/unidata/idv/chooser/adde/AddePointDataChooser.java
@@ -144,10 +144,23 @@ public class AddePointDataChooser extends AddeChooser {
             }
         }
 
-
+        // handle ADDE groups
+        TwoFacedObject selected = null;
+        TwoFacedObject[] defaultDatasets = getDefaultDatasets();
+        String[] serverState = getDefaultServerSelection();
+        if (serverState != null) {
+            // if we have a default selection, search for it within
+            // defaultDatasets and use that as the selection if a match was
+            // found.
+            for (TwoFacedObject dataset : defaultDatasets) {
+                if (String.valueOf(dataset.getId()).startsWith(serverState[1])) {
+                    selected = dataset;
+                    break;
+                }
+            }
+        }
         dataTypes =
-            GuiUtils.getEditableBox(Misc.toList(getDefaultDatasets()), null);
-
+            GuiUtils.getEditableBox(Misc.toList(defaultDatasets), selected);
         dataTypes.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent a) {
                 setState(STATE_UNCONNECTED);
@@ -162,6 +175,8 @@ public class AddePointDataChooser extends AddeChooser {
                 }
             }
         });
+        // end ADDE group handling
+
         if (canDoLevels()) {
             levelBox = GuiUtils.getEditableBox(getLevels(), null);
         }
@@ -205,9 +220,7 @@ public class AddePointDataChooser extends AddeChooser {
 
 
     /**
-     * Load in an ADDE point data set based on the
-     * <code>PropertyChangeEvent<code>.
-     *
+     * Load in an ADDE point data set based on the {@code PropertyChangeEvent}.
      */
     public void doLoadInThread() {
         showWaitCursor();
@@ -681,7 +694,15 @@ public class AddePointDataChooser extends AddeChooser {
         super.handleConnectionError(excp);
     }
 
-
+    /**
+     * Overridden to return {@link AddeServer#TYPE_POINT} for this chooser and
+     * its subclasses.
+     * 
+     * @return {@link AddeServer#TYPE_POINT}
+     */
+    @Override protected String getGroupType() {
+        return AddeServer.TYPE_POINT;
+    }
 
 
 

--- a/src/ucar/unidata/idv/resources/idv.properties
+++ b/src/ucar/unidata/idv/resources/idv.properties
@@ -143,6 +143,19 @@ idv.data.adde.servers = adde.ucar.edu;stratus.al.noaa.gov;weather3.admin.niu.edu
 
 ##Semicolon separated list of adde servers
 
+# Default *ADDE chooser* server selection. Both ".server" and ".group" are
+# required. The format of the properties is like so:
+#
+#   idv.defaultselection.<CHOOSER ID>.server=...
+#   idv.defaultselection.<CHOOSER ID>.group=...
+#
+# <CHOOSER IDs> are taken from the "id" attribute of "chooser" elements in
+# ucar/unidata/idv/resources/choosers.xml.
+#
+# Example:
+# idv.defaultselection.chooser.glm.server=adde.ucar.edu
+# idv.defaultselection.chooser.glm.group=RTGOESR
+
 
 idv.data.tds.radar.servers.proplabel=Radar Catalogs
 idv.data.tds.radar.servers.propdelimiter=;


### PR DESCRIPTION
This commit allows `idv.properties` to specify the default ADDEserver/group selection for ADDE choosers. 

Using the GLM chooser as an example, you can have `adde.ucar.edu` be the default even if your ADDE
server lists are sorted alphabetically:
```
idv.defaultselection.chooser.glm.server=adde.ucar.edu
idv.defaultselection.chooser.glm.group=RTGOESR
```